### PR TITLE
AW-5856: Fix order of politician search results

### DIFF
--- a/httpdocs/sites/all/modules/custom/pw_profiles/pw_profiles.module
+++ b/httpdocs/sites/all/modules/custom/pw_profiles/pw_profiles.module
@@ -504,9 +504,9 @@ function pw_profiles_page($parliament_term, $role_name) {
   }
 
   $response = $q
-    ->sort('has_picture', 'DESC')
     ->sort('number_of_answers', 'DESC')
     ->sort('number_of_questions', 'DESC')
+    ->sort('has_picture', 'DESC')
     ->sort('field_user_lname')
     ->sort('search_api_relevance')
     ->range(pager_find_page() * $limit, $limit)

--- a/httpdocs/sites/all/modules/custom/pw_userarchives/pw_userarchives.module
+++ b/httpdocs/sites/all/modules/custom/pw_userarchives/pw_userarchives.module
@@ -268,10 +268,13 @@ function pw_userarchives_cron($uid = NULL, $reset_actual_profile = TRUE) {
       ->fetchCol();
 
     if ($politician_index) {
-      try{
+      try {
         search_api_track_item_insert('user_revision', array_diff($items_to_track_after_update, $tracked_items));
       }
-      catch (Exception $e) {
+      catch (PDOException $e) {
+        // Due to the recursive call earlier the $tracked_items might be
+        // outdated resulting in duplicate INSERT statements for the same key.
+        watchdog_exception('pw_userarchives', $e);
       }
       search_api_track_item_delete('user_revision', array_diff($tracked_items, $items_to_track_after_update));
     }

--- a/httpdocs/sites/all/modules/custom/pw_userarchives/pw_userarchives.module
+++ b/httpdocs/sites/all/modules/custom/pw_userarchives/pw_userarchives.module
@@ -276,6 +276,7 @@ function pw_userarchives_cron($uid = NULL, $reset_actual_profile = TRUE) {
         // outdated resulting in duplicate INSERT statements for the same key.
         watchdog_exception('pw_userarchives', $e);
       }
+      search_api_track_item_change('user_revision', array_intersect($tracked_items, $items_to_track_after_update));
       search_api_track_item_delete('user_revision', array_diff($tracked_items, $items_to_track_after_update));
     }
   }


### PR DESCRIPTION
The index was not updated when the number of questions and answers changed. Only new and deleted revisions were tracked, but not changes to existing revisions.