### PR TITLE
AW-5909: Optimize fetching dialogues

### DIFF
--- a/httpdocs/sites/all/modules/custom/pw_dialogues/pw_dialogues.module
+++ b/httpdocs/sites/all/modules/custom/pw_dialogues/pw_dialogues.module
@@ -706,6 +706,10 @@ function pw_dialogues_by_parliament_query($term) {
   $today = new DateTime();
   $election_date = pw_parliaments_election_date($term);
 
+  $server = search_api_index_load('node_index')->server();
+  $server->options['excerpt'] = FALSE;
+  $server->options['retrieve_data'] = FALSE;
+
   $q = search_api_query('node_index')
     ->condition('type', 'dialogue')
     ->condition('status', NODE_PUBLISHED)

--- a/httpdocs/sites/all/modules/custom/pw_dialogues/pw_dialogues.module
+++ b/httpdocs/sites/all/modules/custom/pw_dialogues/pw_dialogues.module
@@ -574,6 +574,14 @@ function pw_dialogues_recent_block() {
     return $block;
   }
 
+  $server = search_api_index_load('node_index')->server();
+  $excerpt = $server->options['excerpt'];
+  $retrieve_data = $server->options['retrieve_data'];
+
+  // Temporarily override options to avoid performance and memory problems.
+  $server->options['excerpt'] = FALSE;
+  $server->options['retrieve_data'] = FALSE;
+
   $response = pw_dialogues_by_parliament_query($term)
     ->condition('comment_count', 0, '>')
     ->sort('created', 'DESC')
@@ -605,6 +613,10 @@ function pw_dialogues_recent_block() {
       'type' => 'inline',
     ];
   }
+
+  // Restore original solr server options.
+  $server->options['excerpt'] = $excerpt;
+  $server->options['retrieve_data'] = $retrieve_data;
 
   return $block;
 }
@@ -705,10 +717,6 @@ function pw_dialogues_by_user_revision_query($account) {
 function pw_dialogues_by_parliament_query($term) {
   $today = new DateTime();
   $election_date = pw_parliaments_election_date($term);
-
-  $server = search_api_index_load('node_index')->server();
-  $server->options['excerpt'] = FALSE;
-  $server->options['retrieve_data'] = FALSE;
 
   $q = search_api_query('node_index')
     ->condition('type', 'dialogue')


### PR DESCRIPTION
Because excperts and full documents are not needed in the solr result
used by the recent questions block the options are disabled saving a lot
of time and memory.