### PR TITLE
Aw 5915

### DIFF
--- a/httpdocs/sites/all/modules/custom/pw_api/pw_api.votes.inc
+++ b/httpdocs/sites/all/modules/custom/pw_api/pw_api.votes.inc
@@ -324,6 +324,10 @@ function pw_api_add_votes($parliament_term, $target_node_id, $vote_date){
     $query->orderBy('u_lname.field_user_lname_value');
     $query->orderBy('u_fname.field_user_fname_value');
 
+    // group to avoid doubled entries when there is more than one user revision
+    // Quick and dirty hack for https://jira.parliamentwatch.org/browse/AW-5915
+    $query->groupBy('u.uuid');
+
     // get results
     $result = $query->execute();
 

--- a/httpdocs/sites/all/modules/custom/pw_api/pw_api.votes.inc
+++ b/httpdocs/sites/all/modules/custom/pw_api/pw_api.votes.inc
@@ -145,7 +145,7 @@ function pw_api_poll($parliament, $poll, $subsets = ['votes']) {
     $nid = entity_get_id_by_uuid('node', [$uuid]);
     $node = node_load(array_pop($nid));
   }
-  elseif (is_int($poll)) {
+  elseif (is_numeric($poll)) {
     $node = node_load($poll);
   }
   else {

--- a/httpdocs/sites/all/modules/custom/pw_globals/pw_globals.module
+++ b/httpdocs/sites/all/modules/custom/pw_globals/pw_globals.module
@@ -958,6 +958,13 @@ function _pw_uac_add_conditions(&$query, $conditions = array()) {
     $or_user_retired->condition($alias_uac . '.user_retired', $conditions['date'], '>');
     $or_user_retired->condition($alias_uac . '.user_retired', NULL);
     $query->condition($or_user_retired);
+
+    // get the user revision which was valid on poll date
+    // this means: the user revision which was just updated before the poll
+//    // quick and dirty hack for  https://jira.parliamentwatch.org/browse/AW-5915
+//    $timestamp_poll_date = strtotime( $conditions['date']);
+//    $query->join('user_revision', 'ur', $alias_uac.'.uid = ur.uid AND '.$alias_uac.'.vid = ur.vid' );
+//    $query->condition('ur.timestamp', $timestamp_poll_date , '<=');
   }
 
   // condition roles


### PR DESCRIPTION
Die Idee, die Revisions nach dem Revision Timestamp zu filtern, führte leider dazu, dass ca. 100 Stimmen herausgefiltert wurden. Die einfachste Variante wäre jetzt, die Ergebnisse nach der UUID des Users zu gruppieren.