### PR TITLE
AW-5932 Remove obsolete google plus share-links

### DIFF
--- a/httpdocs/sites/all/themes/custom/parliamentwatch/templates/block--webform--client-block-10369.tpl.php
+++ b/httpdocs/sites/all/themes/custom/parliamentwatch/templates/block--webform--client-block-10369.tpl.php
@@ -60,11 +60,6 @@
         <i class="icon icon-twitter"></i> <span>tweet</span>
       </a>
     </li>
-    <li class="share__links__item share__links__item--google">
-      <a class="share__links__item__link" href="https://plus.google.com/share?url=<?php print drupal_encode_path(url($_GET['q'],array('absolute'=>TRUE))); ?>" target="_blank">
-        <i class="icon icon-google-plus"></i> <span>+1</span>
-      </a>
-    </li>
     <li class="share__links__item share__links__item--whatsapp">
       <a class="share__links__item__link" href="whatsapp://send" target="_blank" data-text="<?php print t('Take a look at this petition:');?>" data-href="<?php print drupal_encode_path(url($_GET['q'],array('absolute'=>TRUE))); ?>">
         <i class="icon icon-whatsapp"></i> <span>WhatsApp</span>

--- a/httpdocs/sites/all/themes/custom/parliamentwatch/templates/node--blogpost--full.tpl.php
+++ b/httpdocs/sites/all/themes/custom/parliamentwatch/templates/node--blogpost--full.tpl.php
@@ -128,11 +128,6 @@
           <i class="icon icon-twitter"></i> <span>tweet</span>
         </a>
       </li>
-      <li class="share__links__item share__links__item--google">
-        <a class="share__links__item__link" href="https://plus.google.com/share?url=https://www.abgeordnetenwatch.de<?php print $node_url; ?>" target="_blank">
-          <i class="icon icon-google-plus"></i> <span>+1</span>
-        </a>
-      </li>
       <li class="share__links__item share__links__item--whatsapp">
         <a class="share__links__item__link" href="whatsapp://send" target="_blank" data-text="<?php print t('Take a look at this poll:');?>" data-href="https://www.abgeordnetenwatch.de<?php print $node_url; ?>">
           <i class="icon icon-whatsapp"></i> <span>WhatsApp</span>

--- a/httpdocs/sites/all/themes/custom/parliamentwatch/templates/node--dialogue--full.tpl.php
+++ b/httpdocs/sites/all/themes/custom/parliamentwatch/templates/node--dialogue--full.tpl.php
@@ -126,11 +126,6 @@
           <i class="icon icon-twitter"></i> <span>tweet</span>
         </a>
       </li>
-      <li class="share__links__item share__links__item--google">
-        <a class="share__links__item__link" href="https://plus.google.com/share?url=<?php print drupal_encode_path(url($node_url,array('absolute'=>TRUE))); ?>" target="_blank">
-          <i class="icon icon-google-plus"></i> <span>+1</span>
-        </a>
-      </li>
       <li class="share__links__item share__links__item--whatsapp">
         <a class="share__links__item__link" href="whatsapp://send" target="_blank" data-text="<?php print t('Take a look at this question:');?>" data-href="<?php print drupal_encode_path(url($node_url,array('absolute'=>TRUE))); ?>">
           <i class="icon icon-whatsapp"></i> <span>WhatsApp</span>

--- a/httpdocs/sites/all/themes/custom/parliamentwatch/templates/node--dialogue.tpl.php
+++ b/httpdocs/sites/all/themes/custom/parliamentwatch/templates/node--dialogue.tpl.php
@@ -97,7 +97,6 @@
     <ul class="tile__share__list">
       <li class="tile__share__list__item tile__share__list__item--facebook"><a href="https://www.facebook.com/sharer/sharer.php?u=<?php print drupal_encode_path(url($node_url,array('absolute'=>TRUE))); ?>" target="_blank"><i class="icon icon-facebook"></i> <?php print t('facebook') ?></a></li>
       <li class="tile__share__list__item tile__share__list__item--twitter"><a href="https://twitter.com/home?status=<?php print drupal_encode_path(url($node_url,array('absolute'=>TRUE))); ?>" target="_blank"><i class="icon icon-twitter"></i> <?php print t('twitter') ?></a></li>
-      <li class="tile__share__list__item tile__share__list__item--google-plus"><a href="https://plus.google.com/share?url=<?php print drupal_encode_path(url($node_url,array('absolute'=>TRUE))); ?>" target="_blank"><i class="icon icon-google-plus"></i> <?php print t('google plus') ?></a></li>
       <li class="tile__share__list__item tile__share__list__item--whatsapp"><a href="whatsapp://send" target="_blank" data-text="<?php print t('Take a look at this question:');?>" data-href="<?php print drupal_encode_path(url($node_url,array('absolute'=>TRUE))); ?>" target="_blank"><i class="icon icon-whatsapp"></i> <?php print t('whatsapp') ?></a></li>
       <li class="tile__share__list__item tile__share__list__item--mail"><a href="mailto:?&subject=abgeordnetenwatch.de&body=<?php print drupal_encode_path(url($node_url,array('absolute'=>TRUE))); ?>" target="_blank"><i class="icon icon-mail"></i> <?php print t('E-Mail') ?></a></li>
     </ul>

--- a/httpdocs/sites/all/themes/custom/parliamentwatch/templates/node--poll--full.tpl.php
+++ b/httpdocs/sites/all/themes/custom/parliamentwatch/templates/node--poll--full.tpl.php
@@ -108,7 +108,6 @@
       <ul class="share__links">
         <li class="share__links__item share__links__item--facebook"><a class="share__links__item__link" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=<?php print drupal_encode_path(url($node_url,array('absolute'=>TRUE))); ?>"><i class="icon icon-facebook"></i> <span>teilen</span></a></li>
         <li class="share__links__item share__links__item--twitter"><a class="share__links__item__link" target="_blank" href="https://twitter.com/home?status=<?php print drupal_encode_path(url($node_url,array('absolute'=>TRUE))); ?>"><i class="icon icon-twitter"></i> <span>tweet</span></a></li>
-        <li class="share__links__item share__links__item--google"><a class="share__links__item__link" target="_blank" href="https://plus.google.com/share?url=<?php print drupal_encode_path(url($node_url,array('absolute'=>TRUE))); ?>"><i class="icon icon-google-plus"></i> <span>+1</span></a></li>
         <li class="share__links__item share__links__item--whatsapp"><a class="share__links__item__link" href="whatsapp://send?text=<?php print drupal_encode_path(url($node_url,array('absolute'=>TRUE))); ?>"><i class="icon icon-whatsapp"></i> <span>WhatsApp</span></a></li>
         <li class="share__links__item share__links__item--mail"><a class="share__links__item__link" href="mailto:?&body=<?php print drupal_encode_path(url($node_url,array('absolute'=>TRUE))); ?>"><i class="icon icon-mail"></i> <span>e-mail</span></a></li>
       </ul>

--- a/httpdocs/sites/all/themes/custom/parliamentwatch/templates/page--test.tpl.php
+++ b/httpdocs/sites/all/themes/custom/parliamentwatch/templates/page--test.tpl.php
@@ -1089,7 +1089,6 @@
         <ul class="share__links">
           <li class="share__links__item share__links__item--facebook"><a class="share__links__item__link" href="#"><i class="icon icon-facebook"></i> <span>teilen</span></a></li>
           <li class="share__links__item share__links__item--twitter"><a class="share__links__item__link" href="#"><i class="icon icon-twitter"></i> <span>tweet</span></a></li>
-          <li class="share__links__item share__links__item--google"><a class="share__links__item__link" href="#"><i class="icon icon-google-plus"></i> <span>+1</span></a></li>
           <li class="share__links__item share__links__item--whatsapp"><a class="share__links__item__link" href="#"><i class="icon icon-whatsapp"></i> <span>WhatsApp</span></a></li>
           <li class="share__links__item share__links__item--mail"><a class="share__links__item__link" href="#"><i class="icon icon-mail"></i> <span>e-mail</span></a></li>
         </ul>

--- a/httpdocs/sites/all/themes/custom/parliamentwatch/templates/user-profile--full.tpl.php
+++ b/httpdocs/sites/all/themes/custom/parliamentwatch/templates/user-profile--full.tpl.php
@@ -288,11 +288,6 @@
           <i class="icon icon-twitter"></i> <span>tweet</span>
         </a>
       </li>
-      <li class="share__links__item share__links__item--google">
-        <a class="share__links__item__link" href="https://plus.google.com/share?url=<?php print drupal_encode_path(url($user_url,array('absolute'=>TRUE))); ?>" target="_blank">
-          <i class="icon icon-google-plus"></i> <span>+1</span>
-        </a>
-      </li>
       <li class="share__links__item share__links__item--whatsapp">
         <a class="share__links__item__link" href="whatsapp://send" target="_blank" data-text="<?php print t('Take a look at this deputy:');?>" data-href="<?php print drupal_encode_path(url($user_url,array('absolute'=>TRUE))); ?>">
           <i class="icon icon-whatsapp"></i> <span>WhatsApp</span>

--- a/src/scss/_box.scss
+++ b/src/scss/_box.scss
@@ -291,13 +291,10 @@ h3.tile__title { padding-bottom: $space; @include text-overflow-multi(); }
     display: none;
   }
 }
-
 .tile__share__list__item--facebook a .icon { background: #3953a1; }
 .tile__share__list__item--twitter a .icon { background: #25b7f9; }
-.tile__share__list__item--google-plus a .icon { background: #fa3f15; }
 .tile__share__list__item--whatsapp a .icon { background: #29d871; }
 .tile__share__list__item--mail a .icon { background: $gray; font-size: .6em; }
-
 
 
 .tile__share:hover {

--- a/src/scss/_utilities.scss
+++ b/src/scss/_utilities.scss
@@ -165,7 +165,7 @@ textarea {
     @include h4();
     font-family: $font-sans-serif;
     padding-left: $space;
-    @include breakpoint($breakpoint-m-min) {
+    @include breakpoint($breakpoint-xs-min) {
       margin: 0;
       float: left;
       line-height: 34px;
@@ -173,7 +173,7 @@ textarea {
   }
   .share__links {
     padding-left: $space;
-    @include breakpoint($breakpoint-m-min) {
+    @include breakpoint($breakpoint-xs-min) {
       padding-right: $space;
       padding-left: 0;
       float: right;
@@ -232,10 +232,6 @@ textarea {
 .share__links__item--twitter .share__links__item__link {
   background: #55c5fb;
   &:hover, .icon { background: #25b7f9; }
-}
-.share__links__item--google .share__links__item__link {
-  background: #f96f56;
-  &:hover, .icon { background: #fa3f15; }
 }
 .share__links__item--whatsapp .share__links__item__link {
   background: #71e9a3;


### PR DESCRIPTION
All google plus share-links and the necessary css-rules got removed. Also a small css got applied to optimize the share-widget on mobile devices.