### PR TITLE
AW-5905 update old sidejobs with categories

### DIFF
--- a/httpdocs/sites/all/modules/custom/pw_sidejobs/pw_sidejobs.install
+++ b/httpdocs/sites/all/modules/custom/pw_sidejobs/pw_sidejobs.install
@@ -70,3 +70,29 @@ function pw_sidejobs_update_7001(&$sandbox) {
   $sandbox['#finished'] = $sandbox['progress'] >= $sandbox['max'] ? TRUE : $sandbox['progress'] / $sandbox['max'];
 
 }
+
+
+/**
+ * Update old sidejobs with no categories
+ */
+function pw_sidejobs_update_7002() {
+  $row = 1;
+  $path = dirname(__FILE__) .'/update-source/jobs_category.csv';
+  $handle = fopen($path, "r");
+  if (($handle) !== FALSE) {
+    while (($data = fgetcsv($handle, 0, ",")) !== FALSE) {
+      if ($row > 1) {
+        $uuid_sidejob = $data[0];
+        $tid_category = $data[1];
+        $sidejob = entity_uuid_load('node', [$uuid_sidejob]);
+        if (!empty($sidejob)) {
+          $sidejob = reset($sidejob);
+          $sidejob->field_sidejob_job_category["und"][0]["tid"] = $tid_category;
+          entity_uuid_save('node', $sidejob);
+        }
+      }
+      $row++;
+    }
+    fclose($handle);
+  }
+}

--- a/httpdocs/sites/all/modules/custom/pw_sidejobs/update-source/jobs_category.csv
+++ b/httpdocs/sites/all/modules/custom/pw_sidejobs/update-source/jobs_category.csv
@@ -1,0 +1,2239 @@
+uuid_des_sidejobs,Begriff-ID,UUID des Begriffs,begriff
+0019e62e-233e-40c7-9951-094ad8ff5283,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+001a29b8-932d-4c96-b7be-25bdec4c1ca1,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+001cf8df-9248-4b28-be25-6c8a5554b292,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+002e376d-4f5e-4a45-b510-7a5337ae4dca,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+00642094-e12d-47d6-bbdb-62dc178406a6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0089f671-6a66-48f4-adec-f88df70a4ac0,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+01101f1c-b99e-458b-87e2-c5c84acd79a6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0139c890-9628-44e7-99ce-b8fffd7a5709,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+019ac431-12f4-4135-8e2a-6c5780ea2f8a,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+01ba66b7-4eeb-46d0-ae04-aaf744597677,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+01f3be7c-be2b-42ad-8c1b-4144d13bd98f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0212f0fc-ae2a-4b43-9b8e-3f6528d99f6a,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+0228c137-e6cd-405f-91b5-efc813557e29,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+023d4e14-0b07-46f4-aa57-2ba9bbc1974f,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+02ce160d-92da-4503-994f-bac66b18403b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+02e15a3e-5559-4671-89f7-b08ebeee27d0,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+030d54d1-1fe4-465f-95e7-694b12c01ecc,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+035550a4-d1a0-4a29-8fd3-dd518ba186c8,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+037b15d4-edcf-4646-a5db-8d2455fa4886,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0390b5b4-dd0e-431c-8481-d4690349ed2c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+039f47b5-59ee-45fe-bc4a-f66e2db1a0e0,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+03a2bd17-f115-47bf-8772-e41c70787f5b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+03c3a33f-723e-4d07-b4f2-04d2f7652df9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+03c54c7e-9470-457d-9104-6e6d8e2448cc,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+044eb79c-a745-4612-85c1-311c180f5b02,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+04697ef5-4e0f-4e31-bf41-8c65eb7c4a79,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+04819d98-a93e-42f1-b24d-f54a9aa11cf5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+04ac9de7-9db4-4d47-ac75-c5e998f942d1,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+04c4787d-7e4e-4ad0-a494-7c1376147000,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+05018f8b-932e-4818-891e-404b2227f6cd,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+0534a490-41ce-4b5d-9994-78e0598b6f83,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+05442d06-9172-4244-bf06-7891c7fe979d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+05471231-2abb-4bc9-a50e-30d94e043e0e,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+05497034-cd5a-452a-bd53-d09f59969cae,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+058a59ad-8aeb-415d-874a-5a968c07fb9b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+0595ac52-189a-4d88-89e3-377444afadc2,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+05976fad-3dbb-410d-84be-7e10c70966ae,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+05c7b14a-a2e0-4204-bac1-283ccf6027f8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+05d3629f-491c-4868-8d14-aa2adc51d2e5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+061742b6-4799-407e-92ef-a3b9d04bee72,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+06788a66-e14a-4e2e-937d-29f508c1bce2,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+069ba94d-7869-4ca1-b3f2-7a86b1363b7d,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+069dd1c1-407b-41d4-9fb8-467fc66017a4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+06b815c2-0581-4c5d-992e-dbd6d8cc0dba,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0724291a-4a68-4ee7-a31b-b09135d828f3,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+0744e030-337b-414a-a8cd-5d53060149c4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0761c6c1-fd9a-48ea-aafa-43893b730c37,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+0793cbbf-a378-46a7-9a41-b4f6b476a871,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+07a440a9-e272-4fe4-adf0-fe74972b77dd,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+07c11cb7-abb7-468a-be87-0424a3bdc41f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+07df008a-d374-41a9-834e-68a72761f6c0,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+083ceb08-e953-4e91-b8a5-36d53d61d0e6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+08601782-064d-4be7-bf22-76e6abf23263,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+086ba4d0-b994-485c-9452-eb845a847c85,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+08726f01-6ce3-40aa-8713-e6d2d3bf5b61,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+08a3041c-e9fe-4f47-b6f2-d4496e97d3c8,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+08cd4a06-f44f-4fb5-a348-9ffca7c1662b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+08de04ff-b36d-4cd7-ac95-869e61accdb8,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+0916808b-95c7-4c94-979b-f4c1a199c2df,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+092164ce-6dc0-4bf7-ae0f-2caf3878ff40,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+095b4f7c-0830-46f9-a975-eb0a98bbe221,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+09861aa4-1755-491a-9cfd-542001334344,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+09a1c6ac-f881-4124-b815-da3d5a96a2f8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+09a1d2ab-74a8-46a9-91c3-6cac5c008177,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+09ab2893-af9b-40de-adc1-3ab4b905212f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+09ab66a3-1b7e-4447-890a-a8e6ef6c7a17,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+09baa1c8-feb5-4ec5-891a-e7640a6c4c79,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+09ef650b-e02a-4a6e-b630-c5036d76a2d1,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+09f6e7fe-d8c5-49dc-858e-38bdcda1c97d,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+0a0da5ee-3a58-422b-b16c-18575adfc61c,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+0a286ce8-d4b0-4f15-93bb-82d7aa509d49,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+0a34707c-b7ab-45ce-8c8a-4c3a85b81ee8,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+0a64bcb4-0806-4d0c-bdef-58cdc81f01bd,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0a7018ab-d2c3-4edc-9477-1709292815e2,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+0a76a89c-aa53-4955-b099-fe66f88767d1,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+0aacbc5d-1e55-4bd2-93f1-8bd5f244059f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0acd3e81-dff3-45c7-8a3a-c9d707bdd770,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0ae06d80-b02c-4546-9692-474a322af684,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+0ae7e560-bec5-4909-b0c3-6e67f6c35218,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+0af7a209-a72c-43d1-a340-001cd49f896b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+0afdf03e-2367-42d0-91d5-e207dcbcbb95,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+0b031316-1353-43d3-ad4c-7349a9843f58,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+0b679c06-3dbf-4654-ad98-9215247475b2,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+0b84f668-fbf1-4c98-b3a9-b9ab1aecc82f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0b917c76-b90f-4ee3-b72f-3f9d3a56b473,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+0be2a9bb-98f6-47b9-a6f2-6caef67725cf,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+0bfbf59c-4262-474d-b4d5-db5c07e0b710,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+0c692b4f-7ecc-4f38-9755-173652ccc92f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0c6e3ed5-e088-45f5-b4d9-90237be6fdaf,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+0c8d7a9c-b81e-40d5-bd36-69f86f8bdb9a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0ca475d3-d6db-4471-b583-7d008c39119a,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+0caeafbf-c9f3-4ecd-8423-e2bf9af466b9,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+0cc778d7-c71e-4f13-bdf4-8e976cd5d603,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0cc7b6ee-f263-4313-a67b-66a6c31833e3,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0cde753e-9b21-42f7-965c-e9fe489c7a7f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0cf32e52-8c93-4bb1-8f9d-74e27ddd2153,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+0cfce6f8-5c0a-46c4-b25b-600bf5b4f816,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+0d3476b6-3ba3-43e4-b8db-29294411aa3b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0d5f2c31-f63b-4ed7-a09a-3238b3fe371a,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+0d856a47-727c-482f-937c-e8ff9ed38e58,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+0d963a6a-c2f0-40b4-a82d-b0382bd2caa1,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+0da3bbec-0440-4ac6-8806-a7ff2509044f,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+0de380a1-4cd8-45ec-84dd-f4b85f80a286,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+0df574dc-6653-4cba-b213-e182d315d026,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+0e300bdd-7c89-4359-8809-48ed8b3d2bdc,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0e643248-9843-45eb-b830-8e8b867730c8,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+0e82dcde-4bf5-49e9-8f05-89680ba1a55f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0e87e3d4-6484-4494-9081-de1706a5b050,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0ebda3c8-ccbc-49e5-8f57-fce587d89edb,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+0ed2af98-f726-4280-a6f4-d92658c69ef0,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0ed74802-b5f1-4b91-abcc-c2aaae92d00f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0ee10e27-22d3-408b-abd6-44169f8242e7,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+0ef01b6e-00e1-4ac9-998f-a3025750bb37,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+0f0f3735-893d-4ff1-97ee-259ee4cd1474,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0f15cb47-5926-40d6-a34a-d3c4cd43c630,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0f1f13ec-0cf4-4f41-b54c-f3f3dae5397b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+0f22b1c1-5a25-4644-a242-9e2905b51ecc,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+0f29b9e2-2903-45cf-82f5-68cca49bb5ca,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+0f41bc5d-2254-444a-8ae7-051fa273cd82,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+0f54b304-4ab3-4304-aef7-cc03eaf6c457,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+0f591b6c-6759-4e0d-ac76-68cf9f0bbd20,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0f600610-d256-4d9d-b84e-544695d84bb8,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+0f714657-6998-4920-89b5-fcf4acc3e44e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0f74cd23-3857-4ef1-9b60-a28abb786a1e,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+0f79b35c-e0fd-4b1f-b47b-5e53bbb5435c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+0f7c180a-44b7-4723-b8c6-5820fc1abe44,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+0f95bd41-ef15-41e7-ac28-8b9b71af6ddb,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+0fad6c24-607b-499e-8580-5e2a771418f7,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+0fcac41e-1454-4ec6-85d7-14d8bcec2694,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+0fefc905-fb50-4fa3-b8b3-b6c3b30f71e0,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+0ffabc5a-28a3-4432-b17f-127293144a63,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+10069032-f9d7-4563-98a9-d2a1dca5bcc2,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+100737b0-3304-4f82-9a04-88371ce1e367,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+102b9d90-b7c5-4ce7-ba7a-f4b6daea8353,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1031062a-0fcd-4f2b-ad89-9bf4ffdbfb68,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+10312cbd-d91c-4365-908a-633d2ad41834,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+103336b9-c629-4983-93d0-b9c02c79dd71,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+105aa1b0-6954-4267-aa3e-d9c26c21847f,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+105c5f9e-c6ed-40c0-9b09-986fc280c3d5,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+108758eb-7523-4ca8-a2c8-dc7474b05c82,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+109a3474-1b32-4b47-aff0-01c8e683f6d2,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+10afa289-b636-48a4-81a0-623de254180b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+10ca0bbe-e538-4531-9f5d-6d16bdfe27ae,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+10eea456-d574-4f2e-9639-84d0b6197294,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+115f29b4-45cc-46b1-b8fd-122bedb4171c,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+117ec975-66f9-4027-aa98-19b19607236b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+11c0fd0c-53bc-469a-a27d-12af9f47754f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+11ff2ab9-c390-4cbf-b1f5-b964eaef4524,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+12192383-8bc7-4ab3-a9b8-500dffbc9ce3,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+12218ec9-95c2-4914-b857-f605f3e8e2e5,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+125003e0-62bf-43fb-af1f-23396ee6470d,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+12514344-7030-49d8-96fc-4c42c6b8b6c6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+125b2375-9000-44e0-96e2-197064fbf9f4,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+12682428-6bd8-4918-b1dc-bdeb47e36752,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1287f024-fbb6-492e-812e-05c25f401f60,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+12b78ece-1e01-4257-80c6-3ab398ee230a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+12dc2442-3fae-4e87-99a9-6db65e85de95,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+12e5b269-01db-49e1-9fcc-d7c83b940b54,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+13104b16-4114-45b3-8258-934d2cbc22ff,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+13360a21-cbb6-4801-a49b-47580a24d73a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+134b3ace-6b6b-4ae8-a1f8-0e5f3801fa51,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+13711ee4-8515-4693-b6e9-ec41c7f5a9f8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+138296c6-517c-4f7d-8426-d326a8273d32,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+13ceee35-16ac-4d94-adae-4f8f0db07ade,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+13dd3c07-97d3-4941-ab2a-c6ef581c0c96,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+142663bb-4174-4017-be91-1c38159d8df4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1428a5d8-436b-4b84-99cc-17addb141b37,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+14310591-74de-4fd2-9133-5ff3eb33440d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+143c8f74-5f12-4372-aa4c-6c5cd4be94fd,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+1475b2a9-e054-44fc-80e3-4373cb36f6ae,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+149ef06e-e2b5-48f4-b1f5-f007c2eb7ee7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+14e5c22c-5cbd-4a0f-b1a5-10574027205b,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+14eb04d4-0a38-44a9-b6b2-fc6d67950117,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+14f9d87d-0e98-421c-a8d1-a18e91ab4a0d,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+15561b17-c2ac-4e7f-be11-35f43843dfcf,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+1565a938-8e67-4bd2-a566-68e1fc487334,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+156ef22d-8cff-472d-909c-f1071bd56f94,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1575cf92-b3b2-4057-aedc-e6a5127e2456,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+157bf2c5-d633-4aae-81dc-1d87eacdedea,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+15b9832d-654d-4a3c-99bd-b7961d6d7a60,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+15bb6c36-f216-4316-acb4-45938b208b5e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+15d76de9-f3b4-4a4b-bbfe-87ab0d36efe9,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+15de1e5e-ee3b-43c8-9c59-ecd6fda27841,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+15e47c79-4f12-4aff-a486-184dce076d9d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+15f9df40-2f58-4a2c-b383-c5840f133346,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+15fde511-bc0f-49d3-9a09-732e98d4d381,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+160c4c86-bc32-4988-85b3-c62df3acc71a,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+16358c84-2975-45c0-b608-8cd6f98650a0,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+1650f0cb-96bc-4ba5-9c15-a5cd2c1d90ea,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+165554df-f2bf-4692-89ba-73a7062ca939,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+1662f289-4bcd-4a49-9a95-1f5037ffbba9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+167e5ee8-8979-4ebd-84c3-0ea001199812,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+168f4f37-77ba-49ba-bf6c-ef5bfd7619f8,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+16a39e81-3bea-4a11-8d30-e124e65cda01,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+16a74ce4-907e-45a3-982d-54e47bc3ea35,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+16ac7a4b-b575-4cfb-86fe-8e2df27b0b1e,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+16beaf51-4eb6-4568-be15-a9d71b70d0cd,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+16ed752f-56df-4d95-b6a3-02be4b89437f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+16f81d92-f84d-4536-ae7b-cd1efa322ff2,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+172068a9-62df-415b-935a-601dbca943db,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+172299fc-4daa-432e-b0e9-91c7d86ea4f8,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+17346a94-14a0-48c2-afdd-dd2e3a096518,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+177f2848-f0f0-4fc1-9325-dae522dd5160,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1791281d-05a0-4d57-8c31-1cfe38b623c3,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+17b635a4-1e7a-4842-b1d4-321bee3915a5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+17bbfc78-088f-4294-8209-5380ca0160e1,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+17c62f16-7da7-4d8e-8951-907c41d5e597,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+17e23230-ed25-4d92-80d7-b4cea5036331,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+17e41483-1f04-436b-a991-812a000c6574,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+17f3a501-0e10-42c5-96e5-20b9321394bd,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+1804e7a5-e7ff-4d68-84f7-0417f9bf19da,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+18064f90-d865-43fc-b707-4b3a447c15d0,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+1813222a-a21c-4348-8418-98b26cb17ed4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+185b9cc3-1814-42e5-80a1-f982dd7df18d,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+185f32b3-8b81-4d0f-9ff7-89dfb46f159a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1869e94d-b782-4e11-9bef-d2fb2d361a35,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+186ef0ce-62ae-4f90-aeac-ffcc008aa869,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+188ce5dc-7c74-497f-be4f-eccdba27bb00,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+189a6193-0dec-438d-9267-722a07d43904,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+189f247a-96e6-4025-a541-3108be5b45a2,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+18b7b854-67c0-4699-ad44-8d887d93b878,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+18e34bc4-c42b-4ebe-8e4d-397ce5c8625b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+19237ed0-870c-44a5-8d13-1350748b472d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1925bff5-e70f-4df0-92c7-2cc3cb00d535,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+192bef88-edf8-4429-89a2-d8e19fa8eea8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+193e2f19-56b4-4e6e-9880-2ebfb3d1d8dd,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+19493f69-d904-4313-b6e6-9f537a52d80f,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+1962d151-1ca8-4d4a-8145-c7d40a6b5ae3,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+19642a15-5ee9-426d-8899-47b43ef897d9,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+19828aca-9e6c-49af-9cd9-13268569dd1f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+198a42a4-c7d8-4c6f-b6f8-b38ddf04b5ed,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+19a8d884-8600-43c0-84d6-a061ec94cc0c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+19c895a3-6510-43f6-b93d-09ea1f4c771d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+19cbc9c5-c14a-485e-b624-63cda271f49e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+19d03a09-6a31-467a-88c6-077c3827bce2,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+19e02f86-96ca-43f4-a64c-425f7c740fe0,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1a06c25f-a1bf-459f-9d2e-fd8f78e5b813,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+1a144165-c545-4b14-a551-009ecacb2cfb,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+1a391dfd-2b39-45ce-bbf6-2df6671ce024,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1a3c059e-e613-4ee8-8156-646e4523a05a,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+1a3ce853-7f0d-4c8b-ba76-2e6e1a6b39d1,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+1a49ded4-1e15-40bf-9b52-fff9b3b38356,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+1a4ea20d-ffac-4706-bbef-2393db2754b8,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+1a5fc8ca-a23b-4da6-956a-0cdbc89967fa,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+1a68b9b8-1018-485a-9f86-a12bf2ad1231,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+1a6e0375-9218-4819-bb49-abe2e912ba70,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+1a725ed1-d35a-4dea-8fad-034ff81add08,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1a908b95-63f1-4d97-b4c4-15ab27c466e1,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1a97f668-1f13-402e-8e62-d0c4d53eaa8e,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+1ad10ffe-828f-4585-b045-5e47395223b7,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+1ad9e3ab-5d90-464e-b74a-0cd3445a9407,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+1aea88e0-b22e-448a-93d4-aaaf4b998a0a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1b32235a-bbbc-4487-9278-a78811d1a8f8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1b3f5fb8-efcf-4f19-9038-6eb564ae70a8,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+1b57aa75-235f-4148-9b0f-4800e039af04,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+1b93227d-6167-4c1c-b827-1e0126fa2b29,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+1bc1144e-260f-4d00-a4f0-047af413e090,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+1c01f76a-5acb-4211-b2c2-78cddf19a96a,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+1c29d8ab-1153-4300-aa9b-1bd6ff25b379,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1c32e255-3afa-4124-95c7-78d64caa0982,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1c367b6e-afb1-411a-b77e-bb0337cfd315,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1c36a7f9-3141-45d4-9d05-fcef30037447,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1c3a3ee9-ef71-4774-8970-4d0ca819f586,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+1c68f0db-05c9-4fbe-bb7e-0a1f4642bb35,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1c972803-058d-49f9-82cb-3e9ec63e719b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1cb91d8e-81ec-4ef3-9f66-3979c40b56eb,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1d01176e-2a30-4e2f-852a-030cc95b52c1,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+1d0e6fa0-ae16-434c-bca4-d26f91b3be1c,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+1d1a3fc6-4e0c-45d2-bf6e-41955606f709,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+1d1c193f-42f6-41b1-8146-471741fd9063,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+1d1f884d-f4f9-4c30-adf0-7098222a759d,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+1d6b2967-983f-4037-9e86-15249834e16b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+1d6be1b1-8713-4b7f-9f2f-92bcd6e15ba0,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+1da3a928-0c9a-4562-807f-734a5489e32c,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+1db53905-8450-43a1-8e5a-04c53b10567d,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+1dc4f82a-6517-4e8c-9ecf-41e92fe7f462,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+1dc5b713-ec75-4817-9861-6ab1a04bc1b0,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+1df08747-e482-4e0d-8453-15dd016303a8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1e221feb-770d-4352-8826-1b15cfeebc23,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+1e6698e6-f2fe-4699-901d-ea56397083a1,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+1e783160-baf6-4650-8685-a9bb6e795123,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+1ebfb4ae-15dd-4237-badb-292e7fec8c69,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1ed610db-0a64-42b7-8098-a1d50b22e680,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1ef7af4d-81cf-4e90-83b6-9968c2986140,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+1efff57b-989c-4549-935c-4663d60abb81,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1f15522c-a092-4a75-abd9-8f16f1e14fc0,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1f2f92b2-dd91-4626-ae27-185d33998ce1,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+1f5055be-1157-4f55-9f93-bd368db8176b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1f56cf82-9946-4a33-9331-a0eb4fd0762f,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+1f747aa8-c1be-4453-9965-e3ab8c7178b5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1f9a1825-0e86-4765-8272-236dfc5e994a,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+1fa1c79a-176f-45f9-8133-8b4bd86bfadf,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+1fb8e468-39ef-49b9-b52d-3e724e8e33f4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+1fce65ba-c51b-4d56-ac5f-148b2c320a74,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+1fedb34f-5a35-46e2-b978-8248de27c8a2,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+200c64af-55b0-412f-873d-e61640d533fe,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+20255ebd-c4da-468e-8899-626a9776fa49,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+203936b7-396c-47f0-bd31-dec5f0f57a2c,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+204d041b-9f25-431e-b7f4-6fcbc4b22b85,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+206158c0-3536-4628-b620-6c791d537eb2,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+2080dde5-a5c2-4683-aacb-055bac0b5041,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+209f0077-657d-47c8-9d5d-dd7e569d08ef,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+20d04d0c-ffa7-4a45-abed-66367e051966,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+2101769f-5713-4e44-8a48-b1d43fc35fc5,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+21036217-ff68-4c5b-bd63-37a9e93372a1,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+210bde02-ac13-46ed-a88a-f6dc1c438c8a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+210f6776-2863-429e-82af-bd88e72a21f6,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+21252016-5344-4f70-926c-f35f5ed6d703,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+2141aa67-4971-4faf-a92d-69e56306fc80,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2148cbb3-e72b-48e6-ba74-61b0ab910886,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+21631a00-4684-4823-b421-f40767a15dfb,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+21773181-8150-4957-ab84-80352cb274ac,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+21919687-2063-42ad-98e3-49a4550cf733,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+21cb1c6d-c48d-4ea9-9e15-3ba5f478a425,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+21d72381-f330-480a-9d72-c2b3d20a83b9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+21dc47b5-2e2b-4559-8c57-3025f4164e39,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+21fc3a55-07c5-4537-bcb3-7d2cd9a876ce,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+220896a5-12e4-46c4-8a44-853c4d445ff7,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+2208bdd1-9f8f-4945-a865-b4a03e5c991f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+2257f70e-3875-497b-897a-d8dab718ff7d,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+225d3152-c0e8-4417-800b-62242a929d25,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+227ac245-3305-4a18-8ccf-d84497412a2d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+227c773f-e65a-4b8a-9708-1c711628451f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+228b395f-bd64-4dc1-9770-bb7067d1ef55,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+22ac34f2-0d6d-4a86-94ff-5080bc78b044,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+22ba299a-5198-490e-b214-9949882f7010,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+22ce9362-a6de-4d01-b3ee-a80e37b45133,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+22f7fcd7-4362-41c6-b2fe-510d78a9f094,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+22f8b60e-365b-4b2c-9e40-8d14e6cf9b98,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+23101508-91ef-4fa0-8844-de49a294b89c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+23508367-2dd5-4256-b64a-de2dbc799448,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+23548898-d422-4c8b-80a1-47620e16127f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+23591ca6-2cb1-4daa-b9db-16beaa3b4b09,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+2373a8a1-2106-422b-9182-8fb88d2da0ee,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+2375585e-2218-4174-9c43-a479c7010526,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+238f18e1-2788-4f3e-a3e2-1b557ecc5f74,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+23cc6c1d-5ccc-45d7-9a88-2df99ce81c2a,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+23d7b575-2ce5-4811-a77c-281c809d5a01,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+23d991c3-6442-4548-bb71-0e40cfd2ac10,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+23ecc147-b93d-46e8-ba2a-cee114b5345a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+23f55e00-612f-44a1-98ce-92ebd9f80d55,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+23f7310f-bcc3-447b-bc87-3467dce74d0d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+24308a0d-9de2-44b4-9c6b-da56ba2706bf,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+243117b5-b321-4807-bcbd-cff1307eedd3,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+24464742-61e2-485f-8edf-1fc6e959abac,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+24587c8a-8020-45d7-8b1c-6fff559b1d27,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+24b50573-6f7e-409c-9614-d441ee56bcc1,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+24c8e85e-36ed-43f9-8c23-c09f97f75892,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+24e48670-a49a-46e4-9a1f-16200d9923aa,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+24f2bd8a-8df4-406d-afe6-da48c5c088ca,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+24f9a702-32b7-4b91-9131-aa274b298bae,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2502893a-e6ff-486e-8fbc-dd1b9f32e703,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+255efc0f-9caf-48c9-8b95-d868d90f3cf8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+256a6851-bbad-458c-8be1-e9ee77e4a7a2,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+258a0495-1c77-48ee-bb43-11e01fffb545,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+25a095d3-e7cd-48d6-858b-c14a1db950cc,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+25b58f6d-e473-4f62-809f-0d7d46418ebe,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+25f679d3-704a-48e9-9c84-04f084911c29,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+25f982c8-3b33-4055-8a44-4b18c384e6e9,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+263cba37-202a-4a45-9aa9-7a5d4ead79f0,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2651c655-4500-4b20-9488-d7d5ab936838,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+26605d47-2525-46cc-b2e3-02090c368255,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2686422d-26c7-41c3-a610-402da7a43c37,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+268cdbc9-6733-40c5-9974-5d7e3e83d551,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+26a0d010-63a6-4ece-9552-ef816f9b7996,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+26abf5da-e4bf-4bb5-a951-42c530e745ef,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+26b34a1d-31bc-40c1-a65f-3fe67a487510,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+26bc5048-e903-4ed9-8083-9d9ef5b12068,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+26cebf25-701c-4879-8385-9156f464aa39,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+26d4914d-8678-4a05-a5aa-4e16c71542bc,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+26f0922f-a03e-40ff-8181-a75027fa9de2,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+270a37dc-8451-44a2-98d8-db9c465ae131,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+2710914d-59fd-45de-8cb5-bcabfa95ebc9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+27193804-9e71-42cb-bf2f-42a15d835fc1,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+2723b545-dc47-4fa7-8ec7-c204746d0aa8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+273ff8f5-ae59-4ed9-be1f-bd0a4b1cade9,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+2764f340-d00a-49bc-8f32-63814bf0026b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+277bfebf-2479-4af4-8996-eb8c66d988af,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+27bc37da-95d5-499d-872b-73b770b63ce7,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+27f5b4a8-79af-4d94-b478-9897251359c4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+28aba0ea-0e1e-4fae-8c56-e641ca704238,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+28b1e91f-508e-400e-bc84-99b26b6cd2c3,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+29226b76-456b-4551-8bc0-4831c60d2e61,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+29252e86-5193-431c-8665-bc257c04d9ee,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+293bb6d6-bcbc-4e67-ba78-8a9c470001a8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+297191cc-dfea-4691-af8a-24a7972dc44c,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+297c9465-3232-4079-ba3e-e120c2cb78b5,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+297ea787-5597-4eee-afcb-ed93da137e95,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+29a9036e-c3b8-4f25-b8fd-da51a64ca55a,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+29b363ea-cb83-4fe1-92c7-bac7408096b9,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+29cb0979-a6bb-4546-af1c-f40d91c34b29,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+29d89b20-30a5-4fd2-b33e-483a83a757b0,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+2a0792ed-4f73-4724-a99a-c5ed8167dcd1,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+2a0fd1ca-9fdf-40fe-91d0-04e5f7a89545,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2a146db9-3db9-462d-af53-64d5d1403bf7,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+2a3a9ea3-f6ea-4b6f-a4e4-1a8634db57b8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2a509eb4-dabd-42a2-b3ca-bf764f284698,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2a790a27-12ae-47a9-a829-f705d8a13821,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+2a842da6-5d16-4079-b149-6835fb3450da,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2abc4b2b-dfd2-4886-9d00-06de697aa343,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2acb5ce7-e6d2-47f4-8e9a-84c05572f4cd,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+2aed1476-1d32-4cdd-a7dc-3dd5c34ca058,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+2b06ba5d-b09c-4e51-b5dd-e3e81c71ef2b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2b0cf5f1-1fa4-4fa6-b9a2-61fb325653d4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2b2209cc-9819-4afe-b06b-c5bf15c1b9a6,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+2b595efb-4649-4c12-b4f1-def304fa6ba9,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+2b6970f6-203c-4f3c-b185-8631b9e2ca3d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+2b93ad0f-00f0-4364-ab94-385d389b37a4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2b977ada-609f-40b7-8f21-277286a3449e,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+2bcfd353-b179-44eb-819f-05054d1150da,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+2c191dd9-8aea-429f-a231-72ddd3b189ce,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2c1c5de4-d647-4c28-a9d4-8cd2e7842d8f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2c1d9fab-a2d9-412d-bab8-737fec864b87,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+2c2d0788-5b4f-467e-a2e6-e1bcca5f36a8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2c813236-17a0-4583-a3c2-e3f89cb51781,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+2c864f32-b774-4763-a3f6-e74063a4913e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2c97aaf5-9ddd-4079-9e99-27f256a2a31a,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+2cb30f5a-c7d8-4df8-81fc-d84f71b391b1,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2cd32179-fc87-4071-b104-ffd65b1dd009,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+2ce4eae0-80d2-40d5-860c-35c2eb7b154d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2cfb510f-02f0-44f5-9400-631cf7698844,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+2d01072f-3de0-4621-930c-6159a7890606,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2d0d78cd-37dd-4619-966a-aa08bde12af9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2d3dcf1c-db4e-4747-a535-0b29c09054d1,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+2d4b385d-d044-419f-b958-0046bbc00a1a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2d64a33d-7005-4676-830a-dc2667e67f68,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2d73e342-b5dd-4a32-a2bb-77e0c09e8945,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2d95efc8-a501-4c2d-a5c1-3af1b01d2703,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2e1a30a9-4cf8-4d75-a95f-7d6385aa18cb,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+2e64992f-5aba-4648-843c-25dc7bcb2939,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2e74af12-3ed8-4e87-81cd-2cabd06aae0c,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+2ead2bd4-0348-4761-8371-4617ca1aea52,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2ebcb966-f9c8-4b51-9c06-3e3b218e07d0,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+2edb29c8-e5de-4369-a5bb-3aa80c5e960d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+2ee9052d-d4be-4312-b6cf-438ffeda92ec,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+2f1ef9e5-c2e2-4abe-b005-c13d59c28011,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+2f2626ac-2061-4031-9819-226e615921d1,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+2f29f94a-02bc-43e5-83c5-842719f2731c,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+2f3952a8-a5a6-4f91-a334-32f0caa94358,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+2f89bbf9-cbb6-4894-8b77-2e6f075af97d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+2fcc25e7-c841-49c2-93a8-6f2798e28aae,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+2ff64368-0ea9-49c3-bf38-bb8d328bb50d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3025ed9b-6641-48ed-9554-855e1edc4a9e,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+302c73b8-74f1-4402-9b83-67efa2abd54a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+306d9cc8-5794-410d-a086-ed6f2fa96674,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+3073b304-add5-4824-ad4a-450cd63f6126,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+307b746a-c112-47a8-94bb-f6f044f627d8,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+30af1530-b46d-4b95-b947-69881bfa4361,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+30cf2415-8880-44f5-9c28-7c196dd7f514,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+30cfaa9a-e9b2-40a7-956d-c998193fd2b5,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+30def6d4-b626-4edf-b97a-6e8f675bf1be,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+30eefcf2-ea3a-44ed-868a-4a3d929ee4aa,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+30f9ee3b-bacf-4157-b0a3-86aa41579f3f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+3118faa1-5e4a-4b47-a5d8-45074172655e,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+3167b69c-ed19-4558-8943-b7e929d7969e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+3167c5b4-6dfb-492d-b767-59d2986c1614,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+31b3b06e-ecfb-4645-84e2-89086156d2e9,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+31b678ab-b08d-434d-941d-23b11c0a0203,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+31c08a05-e108-4277-9687-3a1a4af4209c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+31c106de-4fed-4feb-ae60-6ac6549c3850,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+31d8dd5b-359a-4eca-8eb3-f082caa53c88,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3241267a-e9d0-4df5-b086-b3460f259a69,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+3299cc91-9237-4a37-af54-291765f95893,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+32dc8431-2b07-40c2-be71-95484beb6c8e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+32e4c9c6-f8ea-4cc8-88d9-c282697f6e6c,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+33223fff-ebaa-411f-904d-9f91c2ce4b95,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+33546a51-ab18-439d-8a10-7a3283552c8e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+335c5413-14a7-496f-8ce3-09eefd8ba720,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+336f1992-3452-4255-ad6a-f5c1343e4cda,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3382efa8-c757-4a80-9983-63b28e980ae3,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+3391b771-63ba-40f5-a1f6-390874cab247,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+33b01ff2-c883-4891-bcfc-88740a6ded88,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+33f90796-9d45-41ac-86c9-7cde41f5ac47,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+34042872-755b-48f6-b09e-76a247ce923d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+3441fc51-9fe6-450a-b2f7-de125bea3dd5,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+3489bc54-00e5-4264-b5cf-57f56de9f7a5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3512da4f-8d90-4154-9e53-3d6f3f0a25cf,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+35184a71-acc3-40c7-8d8b-319f0b35f64a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+352aeced-35fc-44f5-9c7d-f3c2719a21bd,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+3556c76b-025b-450b-b05a-e412e9b623f6,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+35708d53-7288-4352-89f0-7557686709e3,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+3570d440-d700-41e9-b1ac-d5322f9bf845,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3592cd22-e15a-4bee-a901-b7c597248f80,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+35b36bd2-62a7-4d06-bc2b-204a13e1819a,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+35bc90d9-aa7d-40f5-b07d-20177a53a1e2,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+35bfd5f0-f8ec-4909-9512-5f70ff85883b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+35cfcd1c-74b3-484d-bc51-90c89378d22d,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+35e87663-85a3-49b5-84a1-7d768f53b063,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+3607691d-1fb2-4558-a5ef-2faa4535cf63,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+36079425-8d0c-4984-ab25-415fddebcba9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+360c1c6a-5074-4994-ba00-be756755ac85,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+36290170-bcb9-4c08-a4fa-96625d797935,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3651d666-d6b5-40ac-9ebd-7f79243237fe,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+36af79c7-6486-4687-b0d7-8f815a43badf,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3722fb51-dffc-4be3-91d8-9aaae9b7d1b4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+374cf22a-2ec6-4d33-b9e7-170eacb0785d,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+3776df18-dc59-4a67-9a1e-ebc12730efec,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+37edbde9-19a1-4240-babf-76fdcd770f0b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+383aeae9-3d6a-4603-95ab-361ba05ae105,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+3841212e-ec9f-47eb-8940-bbc0807c129a,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+384cadbd-4dcd-43a2-b646-b895caa93488,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3856ec92-5570-4d08-a231-bbbf25fdcf0e,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+387de60c-4435-424c-a4a8-22b357a2088d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+38a22d95-2400-4152-8d39-6a355b2b5af1,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+38af52c6-e145-4079-a095-6e90f25b28fb,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+38ca546e-75f2-4850-b1c4-55313b32a3d8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+38f21e19-3b8a-4ddb-8368-b0e2f0b547c1,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+390eb63c-f1d4-4369-ae25-01d667310402,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+391c9f9f-3a2e-4c44-b56e-7feb31139586,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+392b616d-c9b7-4baf-9bae-7cc5d78d9316,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+39358d52-80f2-46dc-8538-bdf2558db74f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+39794292-ed12-40c6-bb5c-44259fd75eb0,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+398f8694-e4a0-4317-a5a5-90049a560611,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+39d62709-621d-433a-b9b9-55df9302b9d0,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+39e5b9a3-cd82-40ee-a792-ad25f926ef7e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+39fbe726-6ef8-4db6-959e-d1ab8f00f19d,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+3a1dac1b-3d96-40ec-9954-c23c612bc444,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+3a215a7b-f18f-421e-a2c8-586284d8d246,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3a2e8fee-1593-41e6-ab2e-eb2e96a76917,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+3a423f70-ceaf-4a61-bca3-2e31733ff1cd,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3a467640-295b-4c9f-b636-d46c6b66bf9a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3a5a3dcf-61e8-4945-9d9e-5dd06ee24b7a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3a5f7ada-5a2f-45da-a906-30285d4c15ca,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+3a77986f-5a91-48b4-b805-7904f81832c8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3a7b300b-13b5-4795-87cd-ee77b73285bc,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+3a86f49c-c55a-40aa-95f0-2200e254e0c4,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+3aba8e10-e454-4bbb-bc95-7622b97eec5a,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+3abdd7ad-7aa7-4b9c-90ab-0afda8275be5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3aca5cf4-3d41-4e7c-925c-7253a883abd7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3b13b361-7c99-4e65-971e-7ea91f4404b4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3b75412c-57bb-4753-a968-b5d23029843b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3b765095-411d-40bd-81b0-55821a507af3,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3b7a7a5e-045d-477d-aaaa-f2601945caff,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+3b8172e9-be07-4c2d-9fbe-640ea6af6dec,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+3b8513e0-a0bc-49a9-b217-d3119c2c22bc,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+3baff21c-82a4-48c4-90e0-854217e3d31d,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+3bf35c87-bbf1-4529-85ba-478b37a7dc0d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+3bfa4ccb-ff26-4e65-bdb9-2f1fb6603547,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+3c2f82a6-4355-44ed-b41e-b9c16bd39094,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+3c35e103-23a2-435c-86e1-c4a42f72f21d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+3c5d1710-b90a-4d6b-a678-e3ea55086f12,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3c7882bd-3e9b-40a9-8ce4-97a88b743d54,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+3c9dbaac-85e4-4942-9d3a-c2de4c9fe304,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+3c9f26cb-bed7-428d-a772-b3115312a20f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+3ca0bf0f-3596-4278-9111-d88411f426ef,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+3cf9ce9d-ca09-49c7-93f4-c6fce8af231d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3d1589ab-f6d2-4a91-83d9-69ff77887938,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3d206158-3def-4d63-be67-3fe44d4d4002,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+3d2c650b-8f41-4206-a16f-9dc7ee457509,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3d349922-ded2-45e4-9fda-7796bcf18ad1,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+3d42527c-2ce3-41cc-adee-73fa7b862e9b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+3d8d7244-4cd6-4512-a7bd-4b6cefeed71f,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+3da2b410-b4a9-493c-939a-0967d4713987,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+3daa527a-6449-4652-8742-e14b1eaa498a,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+3dc4d7a3-c724-45c5-bc3c-99c6676b4e01,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+3dc88012-6a70-4d6d-b17e-9caf1bdf1a75,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+3dc8898d-a37b-48d9-a83f-0e2693a4c5da,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+3ddda547-bfc4-4cd0-a92b-d9ba72a503fb,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+3defd279-7cbf-40a6-9f27-18c73a36353d,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+3e04c6d4-c984-4788-b435-01b02408ca02,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3e09e750-59f4-4019-8082-5280a7886c49,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+3e1381ec-82e3-4301-a153-380a565f7204,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+3e93b479-819b-4987-8a3b-55ed692f2a0a,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+3ea94b08-b548-4b42-ae3b-5d97a63dc9b8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3eaaffc8-eb60-4d10-8134-a4e82fe38546,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3ecc132f-65cd-4c4a-be06-ab7fae1ef0d2,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3ed9a898-7cb9-478e-a188-45801e6f3635,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+3edd4001-6cd6-4509-8b97-c8d17300e1c6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3ef9968b-9d9f-4c3d-9859-317c5098bdb0,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3f0d690d-efe7-422a-8313-828aaa706295,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+3f1fa8da-7d8a-4dc7-a4e5-3570751b89b0,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3f2eefb0-a0eb-4a6a-bd0a-8a3e371c5ddc,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3f374f13-8925-4255-8a5b-09310e80a0d4,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+3f529447-b4c9-4eac-b68b-e516a8d4fb03,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+3f60ad9f-bd62-4668-bc19-0f1ac44261a7,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+3f8271da-9bec-4f64-b67c-388435d78bd1,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+3f9aa759-3fa8-4a8a-9ef1-bbd67379018e,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+3fd625a6-84d6-47ae-be0a-6dbc767794bc,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+3fd841a0-ccf6-413d-baed-9011933cdc42,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+3fda5f8c-87d4-4e27-9148-9f37eda223a0,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+40064c3f-d466-4a7b-b4c3-d8f3e467758a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4040bb2e-cf9c-4914-9994-122118bd1e5b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+4076cc99-5882-45a8-9747-bbcf75e46899,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+407764f3-78fe-470b-8e2c-ee12d601cd31,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4078dbfb-3a09-4aca-b2e2-750f2f6fd105,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+407ca447-cfce-4675-a6b4-16887880a2b5,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+40b14cce-ecc5-4f5f-86c1-65ca08ca2106,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+40b7274f-b40a-4318-a3ea-31273b91baab,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+40ff25f7-97d6-41f5-b034-58be1695db2f,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+4113e416-ec94-48ef-a1ee-17c38bff8813,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4119c081-b4e7-48d2-97b2-61205d251875,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+4164b922-9dbc-4bff-a18f-4c371c38dfcd,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+417af03d-a468-41b9-a060-0b0a40c5f239,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+41b2a2ee-0ecc-482d-94cd-42b7b508e673,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+41d62a59-a0e6-41fc-85f5-1244a58a418a,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+41fcf9b6-a12b-4601-88f1-d99bf9bd18e3,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+420b48e4-6647-4d53-b280-a1c95dbceed8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+421fd790-2caf-4236-aa19-6097b659b2c4,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+4220a72b-ea5e-4e3f-8bbd-781b33a03f95,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+425e5a31-0845-4aee-8b64-dd22a6c0c63d,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+427e88bc-3ef1-487a-9ed2-1ebde7e500b9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+42bc5475-4fa7-4829-9996-2140ee972c99,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+42e3f8e7-3d91-4cea-84b0-ac97e91abde4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+42eb3e1d-c078-42d9-a10d-9c4a8cc00a5a,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+42f70b5a-4d9b-4a91-b93b-85271a63052d,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+431e14af-ee8f-4877-b8a5-224205db885b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+436fed4b-ef8c-4912-9461-f92553138dd3,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+43bb59ce-4d65-4b30-a16f-605c32c612bc,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+43c09cb4-ef32-47c3-a10b-d9ddda7032c0,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+43cbb3d8-fd36-4113-88ef-ec2e7ca47f2a,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+43e70f29-7cb0-4781-b7de-7e359fb7689f,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+43f96795-b294-48cb-93a9-184d0909ce74,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+442baf2a-f9ef-4b63-860a-286c83f89cca,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+4435562e-210b-4fe4-aa32-a6c9dc32aa8e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4455a5c3-fae7-4aa2-a4cd-c96c24f62224,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4496293d-3691-4a48-a405-d8c44450cb16,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+449998fb-b508-4409-a3c8-9e87c3dfc39a,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+44a4a832-a053-41a7-83e9-a464ad3b3681,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+44c6f701-8a40-477f-8c66-91ab86c1eeeb,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+44ca304b-9ea2-4f38-809c-9c4595fdf5f9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+44dc2a7e-a2c5-47df-9424-571d197e48f8,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+44e6b2d1-a347-46e9-9c5b-c5cee182dc7e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+450e5cc6-7632-44ca-a134-0a142b5bd13f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+4523052a-4448-42d5-a1b2-6e40ec61e96b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+455990d8-dc6e-46bd-99c0-cf1afa4f4d71,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+45849860-60bc-4852-8444-e94845b448fc,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+45a5596f-8cee-40e7-b2e9-5fe208e51331,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+45b3f516-3497-4972-bf4e-f3cd9531db45,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+45bc9755-4d42-48fd-a164-3345da1a9e7b,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+45dc719f-9294-45af-94e6-35c49f8a2c6b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+45fda428-be54-4518-9471-7c6e388f8dda,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+46016dab-d4e1-4d39-b37e-11842429974c,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+461e6427-d1af-49b4-a524-c1b435cf24f0,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+461f249a-2e84-43c4-a989-c14b3487e522,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+462a65f9-55d8-4d79-83bd-2dad2d133119,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+464ba37f-2e51-425a-99e6-3dd68e8286c3,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+4666a171-0320-446a-a74d-f9d7f62c2058,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+467cd096-cc9f-499e-bf8d-c23e5a87b897,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+468a1ee3-5a04-4d9a-b994-618f4b90629b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+468b956d-e500-4de3-ac81-f4971586f661,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+468f13a3-4751-41b9-a33f-190735ae1b48,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+469c1293-f05b-4063-82a9-470462f894ce,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+46b65e27-cb83-4af7-b29a-dcca73addb05,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+46d80004-086c-4d5c-b355-58c14b3ae233,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+46deaa9b-01dc-430a-8bda-57f7d18b047c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4717f39d-9ab6-468d-826c-f3dac80a390d,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+472b1426-d871-4aff-9678-9c17ca547967,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+473c8de1-12e1-4520-b107-d16b74551f71,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+475f4546-399f-448f-b7d0-5ca8febd1ff6,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+476ac526-0fa1-403e-9672-cd35b9c393da,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+47971b0e-02bf-406b-b71e-27b35370aedd,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+47a3e226-de4a-45bb-b791-9dd9009f76d7,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+47a892ca-9a0d-46e2-b8ba-3a6fb1054de3,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+47c77645-463b-4d98-aa67-be562edfbe27,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+47ce9a3c-7add-43a5-83f7-72db73768ba6,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+47e299eb-f162-4abe-a59d-7289c2704c1d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+47f89c8a-79c4-4b47-a029-dbcde72d2164,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+482dd0fd-032b-44fe-9be3-93ddfcc23c53,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+48580426-792b-4298-afb3-ea1dd6bcf1a3,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+48582751-e8ba-4ed5-8edb-5bbff13270ca,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+48793c21-a061-4668-a57f-4aeb7cada454,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+487c989b-89df-478f-8633-9fb8430fb16d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4892256f-517a-43d6-8ee2-443494df349b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+489a97eb-5158-432c-af16-54ca936a57df,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+489d529f-481d-493b-aaf7-81bf9e8d896c,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+48cad0e9-f641-4e91-a419-951f4954a462,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+48dc165a-7a8f-4d03-ace1-18c7f671c4a8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+48dc24a1-df14-43f4-801b-1294d81c8b86,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+48dd9233-a549-4216-a319-b66d57fec9c5,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+48f5136f-3f78-414f-8c06-435e1402a570,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+4931fbf7-db92-4d0f-a0ba-a25624f6e85f,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+4984f97d-1288-4ebc-8b44-df064dedb6da,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+49b2cd78-6ee0-4814-83ba-d5fc178b27eb,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+4a528786-611b-412a-b044-78c5e5b6fbd3,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+4a55b8cc-3ad8-4616-b543-fc102883e577,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4a5ab327-9de4-4abb-8c91-613e14689a42,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4aae7038-7bcc-4695-9e60-d7c5fa2221e8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4ae49637-2de9-4e92-b0eb-4e0c7d327b12,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+4af9cf18-f5be-49d2-9cb1-5c23a435ef1d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+4b0719c6-d335-4619-9d1b-4ca57040c6c3,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4b1ac8cb-82ef-4955-a4f3-434b5d6f1106,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+4b2b79f5-f000-4dee-8cc9-0eb9486381f5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4b3b6fc0-0ca5-4382-afed-5ecb2989888b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+4b55ea93-b98b-45f8-92ba-6fab8e707ee4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4b5cce55-d54b-4cb3-860a-3e3ae2a0b75b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4b63b06a-6f27-4019-a570-0079d8398631,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4b785742-6789-4a2f-8b89-f6c88d992fb5,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+4b80ef1e-6512-419e-905b-1a173a7e0f6a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4bc1ba43-5b98-4daa-bc52-a8933dd28e74,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4bc291b5-28f2-46a2-95b5-d9fc8cf4078f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4bc31507-99d8-4b01-92cd-90e17ae1909f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4be6797b-6209-4839-888a-bdbaf5925b98,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+4c242785-b8bd-4af9-815f-4405bc6b3cc7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4c39ddc5-ffc9-4c93-a911-c9c9d4ed975b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+4c5d32e6-bd0e-41f4-84ad-2ab511c0ada9,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+4ca17ee1-0e5e-4487-b6ef-e9344093f921,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+4cdc70ae-1832-4dde-9bed-388af0f74d3c,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+4d1c1ac7-d8fa-473a-828e-9297d0f21e06,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4d2d1ff6-116f-49ee-8e94-7e3a1822c908,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+4d885f73-ddf7-48f3-8982-4cc7847d7a34,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+4dcefa3f-e9fe-4464-9c91-d1980d1c42f4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4e3310f8-4131-4030-a618-c413ab93e452,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+4e571af2-1508-46e5-a341-48d15af9a3c4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4e7cd975-d5a5-475a-a859-b3e8f9a1946b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+4e84f5b4-244c-4c64-86d4-46b64d0d0b75,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+4ea6c437-0105-4c1a-9277-41909631b8ee,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+4eaab8ac-f156-4aef-b260-caebe4fef865,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4ed505ff-46b6-4a97-953d-c24f696f1668,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4ee97ffd-3ec7-4b21-ae69-b630b714bb8e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4ef98469-e66a-4118-853e-88bc1cae077e,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+4f1c5c3f-fcf7-4e2d-b7a9-e64d29e745d6,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+4f3404ff-ceec-4921-90a9-c156c95f898e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+4fb5959b-1837-40fa-8b11-958ae09b3682,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+4fe4ca16-aa68-4b91-9dea-b6916bec4dfd,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+4ff8d213-d61e-44eb-9f0f-ba30d1ece96f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+501f07ec-7682-4a6a-baa3-79f96f4ec89f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+50400409-a1ef-4064-bad8-fafc01b1e7cb,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+506ed3f3-0dc5-4ca8-9b0d-cd263b0fc2c1,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+507b1f69-836b-47c2-9935-4204c0f293d8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5085eadb-1ce9-4924-91d5-94c58abee767,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+50892cdb-a67f-4fe9-8054-b8d0e4d9dab6,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+508f6e38-521f-488a-915c-43b19ecebb96,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+50a70684-f5cb-4d45-bcb7-ecc55e95d058,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+512ed0cd-5df3-477a-b0c3-7d2c5b256e68,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5133e4c6-1456-41e8-9252-143a4bf01606,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+516d0d50-689c-45c2-9a1c-f88d9a685f58,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+517018d0-1441-4722-880c-bfc7aa3101dd,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+51722b5e-de64-45d2-b6e4-c727bf65c523,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+517af5fe-a02f-4d38-a2b4-186c8635191d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+517c4e23-c610-4ade-aa95-13fbf5c4b9b7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+51abf228-00e0-45d1-a45b-c59e47521ebe,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+51c97f64-6a05-4257-92fb-dfb55998f72e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+51cc8b88-3aff-403a-85fe-d50c89bb2e2b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+51efb8d1-d43d-4981-97b2-c9a8d0aa7f7d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+5209460c-553d-4f47-b2f0-6611e1610a4c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+52218a3b-35de-4e11-8484-89609ccbcb75,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5240ae51-a6eb-495e-8443-34fcc98a03b6,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+52460c4b-0127-4d70-a344-74bf1c082d3c,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+528b6d93-3404-4146-815f-7b8b15a16edb,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+529e1485-5a3b-4935-a792-ee3f39d9d4a5,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+52a41aea-456d-4f2c-b901-6e6548e2d9d2,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+52c9e9ca-a527-4648-bd6f-298a8ba7c462,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+52deb354-16e1-4143-9e4d-338af528dec7,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+52e492ae-1497-4bf1-8288-188c8b748081,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+530a74f2-5cfc-4a6a-851a-cbcbe24b2dad,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+53ba026b-24f8-49ab-9d5d-dd377858bcab,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+53bd1f5b-4d32-41a6-a4ce-fd8e7521adb8,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+54020b6c-e5b9-45e7-bae3-f45e9019d526,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+540e9181-39ef-436c-b9b2-241be5c520c1,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+54170082-d237-48c7-a95f-eb12b1b9e6de,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+54852df7-20d6-4b09-8b70-0eff32d54790,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+54937460-2b7f-4f5c-9fb2-577c656ac42e,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+54e48b5e-315f-4360-a3e8-ff6149447cb0,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+54fe81e7-2f50-4ff9-a007-c916da4baa45,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+551554cd-fc7d-49a4-bae2-91adcf7a89cb,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+551c89da-929f-471c-94e5-89968954213e,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+554453d9-fb98-42e2-9149-2db3217536a4,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+55501205-4e2c-4582-ad5f-95789cb9ae8e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+555833e5-2d29-45a0-8def-818ebd0954db,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+5562aecf-1c29-4628-b92b-b613d9564f8a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+55df022c-ceed-48f0-933a-4944c2247672,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+560b27b7-7868-4659-a8a4-41c4cd95df8f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+561b1b6b-aa77-40bf-925b-6ccf858fe9ef,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+563fd69d-4c97-4be3-bf81-b0f60e52a009,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+56490657-49d4-4fb9-b17c-375cff6afdfc,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+564bc8a8-9dc1-4816-af82-0216a8770bf7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+567080ea-c617-47e4-a011-8e75fd143cb1,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+56c06aa4-5022-46bd-90ba-2f8abc9fafc6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+56c81357-fa18-4fb1-b3ef-6f683d6436e1,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+56cf1b4f-1b07-44e3-8421-764b8dca5b63,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+571d36c8-1194-4895-ab66-9397f533a0a8,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+57218669-2ca7-45e0-a456-f21c89db26b9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+57336e64-c1ff-4250-a752-d0c4508f3cc5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+575851eb-9de0-48ef-b100-b6f972746ed4,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+5773f09d-0b69-4a24-9c46-5f6f9e441f46,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5787fade-a605-4480-9463-64bd83d10015,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+5794ad67-6759-42c2-a2ff-ed682f21bd6f,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+57d8d400-8962-4535-a3b4-dba8b41ac984,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+57e39b58-3545-4e62-abbb-97b74c4d38dd,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+5803964f-607f-4e31-954d-d8b2ae6c0320,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+580c943a-6edd-4291-a36d-72fa56fd04e0,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+58201a85-f003-4558-bbf4-c4730b564338,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+584f18ac-927e-4d94-bdcc-3a485e654965,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+586d756a-1fc6-48e0-9054-9ae23327dacd,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+587089e0-ecb7-47c5-a614-62652fe13841,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+587d372d-2896-43e1-bacb-0870e5c3d51d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+58aa5d4c-5182-4012-9416-6f1a8234adb9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+58f45cb5-5622-4c21-ac22-967853832ade,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+593eb924-61f6-4e01-9bc0-71160b12c066,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+5948caa9-7506-4ab6-b2ad-b0de6375c417,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+594e25e4-e0b0-47a9-b21d-2892e23f1bb7,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+5973defc-f4f0-4d92-8fa7-edd81b6ce9d6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+59a1b0df-d61c-4e27-bec9-535957ca83ca,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+59a4678c-9cab-43ff-8250-ec577f9e5650,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+59b8fbe0-f4bd-4538-a030-9e6838459975,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+59ee37ac-71c8-48ce-bdea-21dfbf22e5c0,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+59f5ca1a-6521-44fb-9bc8-45c34090e7a0,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+5a02ee95-2e3e-4baf-a804-d6a9732418e7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5a096389-f836-4350-bd3f-47bdc0aca5dd,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5a0c48ef-7968-4f21-9d6b-69e5152b17c9,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+5a17f2f7-6c1d-40f0-8499-8bff67c57d7a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5a626682-1213-43c0-b9f7-79f210733d08,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+5a7bc40a-d86d-47fd-a35a-9b8ac37e6a88,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+5a8e2f46-eb3e-4fec-9823-726dffe70cf9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5a93ce2c-55b9-4df6-b895-9efde39fe26d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+5af0311b-68a5-4c75-83e5-61c8616fa7d3,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+5b113718-7c87-4f1e-9744-ea0c05132902,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5b2d6236-7990-4ab8-ac2f-ee8c7e2a78c0,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+5b38b7c6-0de7-4cc9-9201-cb9655c77c3f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+5b4db37c-c43f-41b6-b3b7-ec961d334836,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5b58c51b-be89-4112-9afd-ac1625e40fbb,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5b94fd12-3598-4f38-9e23-2ec7d6a027d4,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+5b9e3267-c8e9-4d29-9bc1-9ef66aa9573d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+5bad9260-183d-49fc-9a05-e2eba99d24c4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5baf39b4-4066-4e10-b0a0-c5b229545f30,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+5c300b7f-9dea-4d60-a209-eacd4f13c951,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5c628683-a8ff-4e0b-878f-c41dc3601ea3,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+5c663e44-c892-4d66-b53a-7b2dfbd7b129,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+5c8330f7-2e36-4fa9-a2df-d3726e5d4bae,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5c8a3501-277f-444b-9599-25552a9661ac,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5cce7e74-e3c3-4fd1-ba0e-06c4c94184f9,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+5ce01d61-b435-43b2-aee3-35e0c37d8e41,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5cf05797-c0f5-4c08-97fe-390e71c1a8f2,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5cf28b47-47ff-469b-ae92-f1c882e3fc26,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5cf5d479-4a81-45f4-a2c4-caba88691054,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+5d15636f-0867-42b8-9d19-679498c516bd,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5d49e5a3-6f05-496f-bcbf-3d3d3160ebf9,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+5d600c4b-dd5b-4ae6-ab67-ae155c213c11,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+5d739310-d797-47fa-858d-c64280a9d3f6,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+5d91092c-24d8-4417-bcd5-fbb9453f4212,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5d97523e-aad4-4607-a606-814bae4be378,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+5dd8c18f-d886-4bc6-81a3-5006428815cc,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+5ddc5a75-246d-4f4e-8c71-6325aa3c728b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5ddd4e20-bdc2-4d3d-8f95-b59f49e57c70,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+5ddda0b2-11ba-497d-9a23-d9b2637d6e18,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5de0925f-255f-4426-a6a2-115de9c510b9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5df9a9e8-558d-4481-8265-e1bfa63b9689,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+5e045df8-2af4-4551-a226-4acc08752459,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+5e11573e-df14-4c05-af18-b0b23d06c226,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+5e515268-bc48-45b5-a860-bf70986f0a23,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5eb43b86-a3e2-4f98-8486-a24f7605bafb,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+5ebcfa65-770e-4c71-997d-cff3c737d4e7,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+5ef4d271-bd80-43b7-84c3-3d95b8ae85fb,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+5ef5e45e-62e8-4486-ac72-dcc89bba6515,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5f2184df-2b66-4010-a965-0407e2e30e50,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5f534949-997e-41f2-ad3d-3a0131b65c79,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5f66c175-5281-41b1-8c5a-cec9aa614227,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5f80dc21-e124-49f0-8591-05de7bf07b73,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5f918ec2-149e-4603-9e13-320f6140735e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5fa715d3-516e-4950-8892-eb19ad002ce4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5fc579a0-0fac-4fd4-bc2b-efee5b3ee4a3,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+5fcd9d5a-822f-49bd-8781-e865b6e2f98e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+5fcf94b3-6bbd-4ecd-8626-00f7e1cb2fc0,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+5fdd1df1-ae5e-4507-8f41-0c7d06aaa38a,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+601b2927-daa3-47cc-86cb-8d37603a36ed,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6055e12d-b425-4ae5-8b5a-837fc03c0e61,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+6061938e-3337-478c-affc-e98de209d3d6,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+60745db2-1b79-44fb-9848-605d521f57e9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+60c0dff5-ea29-46ec-a633-538692abea6a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+60ea5820-8cc4-492f-a2d1-26b897dc9c45,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+60fb2a5f-06e6-43b0-b096-335816120719,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+60fbccd9-4562-4d9b-b472-dfbc5bea7577,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+61158750-f47d-426e-a7ed-23a45ae662a0,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+6129ee60-6883-4523-b332-6619bdab351e,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+615546cb-d18c-44ff-afc0-2a6c91d9924b,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+61600309-6bbd-4e17-a47b-e60da99e90a4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+616f0446-0ff9-4e60-a94b-ec5693b38d4d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+617084b4-05d9-4465-ba05-09a1d49f8a1d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+617e3d4e-5878-4c70-b2ad-c41c4fcdaf93,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+618985bd-d128-409e-afd5-11208c9bcd7e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+618a380b-4343-4d20-8271-4c76f27c205f,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+61a4c399-4d2a-417f-b481-5e7475dd413a,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+61a86926-674c-4a9a-a75e-cadaeb698203,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+61b7e3f3-dd95-45b2-b3b7-9dca508dead3,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+61b98a0a-c4ab-41a1-be83-eed4d597e7a8,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+6231e6e8-3a2b-48f2-a323-15c9d00798eb,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+623c07b1-ada9-4d0e-9c33-41a5e546d947,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+6268c8e7-6387-4e35-bcd7-ff3844665c61,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+6272cc32-bac8-4edd-a5d6-239df2baa3a6,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+6277ca2a-abf6-496e-9f56-9ee9a41cbafb,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+6285becb-0988-4a5c-9204-5b7e7902317f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+62c302e2-268d-404f-8dda-48e64521dac2,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+62c8a413-e5f5-4005-84f8-46fedf9d244f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+62cf230b-3ec8-4de3-8420-6f3cdae791d4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+62e30584-eeec-4ad2-9007-30ede355a9e7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+630e4f46-86e8-4267-881f-6c38317e2ce3,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+6314b191-d16c-495f-86ac-4825c71a40da,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+63245126-1fa1-47e2-92bd-921a8cef6776,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+63696e1f-d781-4630-a6bd-9d0018e26b1d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+639fae83-abf1-4f64-aaca-d235ee118bc4,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+63a5fdbb-1fd0-494c-a446-426f4f34ff56,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+63b495c9-4110-4fbe-ab33-feeb4c9efcef,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+63c7cce3-af45-4bd5-b05f-1148ed2a092a,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+63d5d883-2908-4ee2-93fe-cb48158a2f9b,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+64387420-adf0-4e13-be94-e43ff8e46fb3,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+643be80a-c4c2-4f7a-b7f7-23a9ef595c82,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6446337f-e7ce-49fb-829a-26ffdd49e934,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+645a0464-b0ae-45f4-951f-04356f147ebe,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+6464479b-0105-46eb-9050-a7ca49a6b94e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+64738c1a-1d08-4a8e-a0f5-18ec0fe4a5bc,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+648d5a2a-a55b-43b7-b6aa-b294e66fbfa5,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+64cb452f-4b68-4396-b5a4-555d2fd98084,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+64d474a1-2144-41bd-8901-8e38da4995b5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+64df31a7-7368-479f-968b-03a13854bc4f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+652047aa-baa8-4958-8ddd-09dc70d2239e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+655373d9-6afb-42b1-89d0-079e953d0681,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+656485e6-ebe8-42a7-8818-b2642c3096a4,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+656f6476-9ef9-4e6a-9bbf-72f4a94f6d7b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6571a692-c086-4669-8380-9df663d154c9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+65bdb3e8-55a7-417d-8e24-8fedc7ca2346,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+65dbbbc1-fe5b-4198-a621-e8cffe71a439,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+65f5d459-21a2-47ee-8917-ca9ce3620565,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+66326162-c5fc-45e3-b82b-42dc630b3bd0,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+663ecd7a-4ac1-4013-afdf-11fb8912197c,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+667497ff-2cc0-4492-832d-9701c692d712,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+66c3d904-9c0a-4acb-a723-94f863121730,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+672a91d4-a4f1-42c8-92cf-61870090a807,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+673105fc-044c-4e90-b8f1-70da4b8f6807,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+67340b72-327c-4ce0-a350-28743e2d3673,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+674d7e65-297c-45ac-9c65-74901cfed77c,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+6757299b-6685-46ec-81ac-77c9e8becd91,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+677db589-96eb-4652-ba15-884dfdf5c8e6,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+6793a4bf-e2c2-4699-8f88-f72b412b75c1,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+67c339bc-61e9-48d5-97d0-a90df02f09b5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+67ddbfee-2498-45d0-8f6d-40680f4d7ff7,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+67e70efb-94a1-4638-bcef-1b3cc006b95d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+67f979b6-e2a2-4d4c-9bad-705cf810342a,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+68066d50-9773-4783-9ae5-c2ebe176e810,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+681cb1b5-32d5-434e-a6b6-bfe090c393fa,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+682bc20d-f713-409e-9aa4-dca8807ff3f4,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+686b4176-b9ff-4698-a419-f73e3192b80f,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+686e5516-eb21-4520-a4d1-5f24f09c99da,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+688cd59b-7d45-4558-b261-7af20ecac116,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6898140e-20e2-47ef-8d5a-a5e83c5e97b6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+68e02986-f9d2-47af-99dc-e656b9361e12,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+68e7ebda-5cbb-44d1-ab57-f66183352ab9,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+68effea8-238a-4f43-8df4-ef1803e53602,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+68fe7294-dd6d-4c6f-9c6d-1d267eff751e,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+6915a150-538d-4a76-99f0-3c05627d26d4,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+69536dab-4dc8-4d4d-ab1c-93ca637b3488,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+69541759-61af-4c2c-aa53-e7d8ffd7ee71,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+695bb5df-6e79-413a-9dfd-66f4cc68a888,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+696f5d41-3883-45f2-9fbf-0f7aa94d8eb9,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+69897091-f105-4df1-9ca1-29369e845c9e,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+69a65c52-6f4e-4357-8d81-e58fbbc5166c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+69ae8d02-e05c-49d2-829a-23909daa3f2f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+69afe1cb-2431-4aa7-8677-d617db7f438e,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+69dc2c56-3cd3-43d2-9958-d200440ff1f0,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+69e1f0e0-80ab-48cb-95bd-98179d0e602c,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+6a07d28a-ea93-4f3a-a38e-b8e8af20f0f7,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+6a1af1d6-ed99-48f4-afd3-d22f2141efca,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+6a35ec9b-3f52-4969-980d-803f321db5d7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6a39199a-648f-4ae3-8746-0b702e4498a8,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+6a3f1185-1d1e-4c0a-b895-fe6158de9270,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6a4218ed-244a-4e32-9331-76a632a40f2e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6a4ed8dd-be7a-4351-85f3-55e9d2655cca,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+6a685016-2cbb-45af-8c68-9dd82ed23724,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6a758eb9-a265-4dee-9501-3ce58e9dd46e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6ab0909e-982f-4c75-a82b-5793a357ea09,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+6ac98acb-1f0a-4dd8-8bd5-9b9446ade5b0,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+6acd497a-a24b-47a1-b713-f5a34a630539,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6b42d393-345d-4580-9bff-57b3db8c16da,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6b7960c5-8acf-48b2-8376-25101316472c,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+6b7972f8-7509-4d48-8c94-ebeff9d4356f,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+6ba0be77-fa8a-4453-b7cb-daaf0571536f,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+6bbe47ce-460e-44ac-8f9b-707066afbf64,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+6bbf7c13-b8fa-4e6a-9f20-d31f0edfa9b1,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6bc033f6-6056-42fc-84cc-2c08b168e05d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+6bcaf729-ac71-4131-bbb8-dd25712765c5,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+6bdfd818-ab53-40f9-a352-8f69d47db363,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+6bf6aa27-a3ca-4d5b-aa86-5a907f18c31b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6c192405-9942-4dc9-b1b8-1bb5f3b6524a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6c265591-1bea-429f-b59c-8f0df2c9d8b6,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+6c48fe5b-fd4a-4d94-b5dd-754777b02647,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6c6ecc7d-2003-4b9a-859c-57a4d803a290,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6c858de7-224b-456a-8a45-31d7492a3980,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+6c9a31fc-5fd8-4194-914b-68ada8c9923b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+6ca42d80-7597-4203-9bee-83178e9133e4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6cd91d67-0c45-4059-a217-d8653b7b5a4f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+6d064bee-137b-4822-8172-3c38e25cc94a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6d1dc1e6-c3a9-4513-8180-101db1faa31a,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+6d317953-ae53-4079-a081-19a2cf789de7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6d32e0bd-555a-4e75-8fd1-2e16c689448d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6d34c15a-56d2-44fb-941b-b758dd22c13a,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+6d5a3c36-0484-40e6-9a85-0ee3f2105b63,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+6d695346-c813-44d9-b629-9e6a17a7c5e2,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+6d79fed6-8fbd-4b6d-925c-092a7e6b71b9,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+6d984dac-b2bb-4089-92e7-d282b8ad0649,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+6da92fa6-0699-4349-ac72-78da111b9b30,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6daa16d9-4f34-4f19-8fc8-b8510432fbd5,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+6db6a85c-f5f4-49c0-a9e8-aaa5f6665446,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+6dc0056f-8572-4648-91bf-0ec501a713c9,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+6dc6f056-fcf7-48c6-b5fb-36e5687f7a1d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6dfd5e7c-95ce-493d-ab3b-95f4d0da2d79,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+6e02a7cb-3323-4a6b-91e9-b4e3076fa791,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+6e071ce9-9b57-4613-a539-d608e201fa9f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6e159bdf-e333-43e3-9f5b-3e179b3df026,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6e5da717-2656-47b2-8b3d-52a85b31b958,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+6e5e8275-c8f6-4440-8b4a-5a75ce652c68,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+6e8de166-8542-4ca7-a918-ef341e123f74,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6ea08296-dcef-4d93-96ca-0e832c6dd2ff,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+6eacc8e7-d41a-4312-80b4-11c57c4dd948,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6ec2dbc1-7f6c-4d14-b5d6-0897c3687252,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6edf9b63-da75-4ad0-9312-b5ebd35f2c4b,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+6ee1cb8b-4092-4e64-94cf-e0a4b1d089d7,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+6ee6b05f-6896-4de4-8c49-17060e4e25af,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+6eeecbd4-96a6-45a4-bc1e-64b7d4e41d0f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6f6f72f4-6cc9-4dfd-a9e4-ec1a27616b7b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6f7f112d-f800-4e91-91bd-6c0d22cb5690,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+6fae321c-5db8-4c69-96f0-5d3dffd24668,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+6fdd746d-87fb-4ba3-a675-4d2fe874f4b6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+6ffeadb6-6ef2-4c96-b62f-65af19a99b3e,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+7011d97c-8576-484c-a70d-095efd4b535f,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+7014199e-cce2-427b-8e68-71f285e4e81d,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+7014eb81-69be-490c-805f-bae0b280c03f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+70170851-f939-40d0-b491-7fc077976b76,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7021f0f4-750f-4431-afc4-03112d865573,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+7024b92a-2ac0-4f30-be87-14f44391fd88,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+702c6808-b7f1-4748-853e-d9a9f9c8ea1e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+702e22e6-e7c9-4329-9643-54edbef57ec8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+704c1fb3-c8b3-41cb-877f-1f5c3c44bb60,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7067989f-80f5-4221-ad04-c9e3970d157a,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+70fdcc62-ba7f-42b8-b4d7-fb518271c05e,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+7160c973-b17d-489f-91ff-39d43058e175,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+717d3758-56ce-4a2a-bdb2-58aa99fdc47e,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+717d723a-b6d7-4274-a43e-45bef8aaf744,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7195629b-970a-41ae-b9dd-a4a8cf3e427f,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+719fd437-6f28-44f8-9593-cbb3080ab8b2,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+71a2b3e5-87b5-40cb-84d1-5b424331751f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+71fc12e4-6bb8-477f-b43a-074215389f47,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7215e158-8b7f-43b6-adb2-7a9eb88f351a,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+7221c136-b153-4fee-9c72-5ce941365895,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+722acca3-5796-4c0d-b8fa-9b266e543add,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+72336146-fba1-42a9-9e89-bbd4528fefcc,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+72808bae-5546-4722-8741-9f51c3b8fd8c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7295c1b8-a11c-481b-b6c2-e6f7ee3d9628,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+73077e3b-9b1f-442b-ae0e-cbc9ac375c6f,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+73086686-b3d3-409e-b13d-1e85291e45e2,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7346c052-f12b-46ae-81e3-905ad4757f71,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+73c25ed0-7e87-4c9d-b09d-f785821af8e4,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+73c54c47-6369-4faf-8dd4-bfa44d799365,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+73c77b5b-0f80-4c96-b62b-4920c4a115c1,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+73ca1d74-432c-40ca-8762-3f2ec3b93397,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+740a6665-c2c0-42c2-88ed-5ecbb6ddf558,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+741cef38-edd0-4511-a5ab-34cbeeaa48c8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+74211b92-6de5-408e-b764-f77cac662449,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+742dc51c-7230-4608-baf0-b9f432b14608,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+7444341c-fda3-4807-86b8-740be9f233de,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+74550af7-c0cd-4ae4-8777-a88f2b5e9a79,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+747efbed-d6c8-4d9a-90fc-a686dfc934b3,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+749aa99b-f5f7-4d14-9ec5-5d645c4ed8ee,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+74a83119-d091-47b4-a022-657679f70b52,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+74ec1fa5-410b-49e1-b21f-f4d5e3d22e5a,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+7543f30c-b4c2-4fdc-aaf8-c1d19fb3efc3,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+75638b84-dbca-4a61-9b08-008dc2704e6d,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+75864e55-7970-4255-8662-35044596d399,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+7586a52f-f6e1-4ed0-9f42-e7b7340d8894,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+759e28cd-0e69-41fa-ac07-5c6614a7d61f,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+75ab6e5e-817a-47a2-9838-4550bc5ac788,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+75cb3306-c23f-4b2c-aafb-a76bf4c4b257,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+75df7e28-ba20-44e9-8439-4279095afa82,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+75eda79f-a8e8-45b5-8a2b-d79c829c24ef,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+7610e741-7100-45f7-bc7a-faf724543833,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+7630dde9-b903-4a8c-9284-8a6f9d7d707f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+76ab6fe8-1e42-4149-9fb5-6390854755c3,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+76b4dea2-a2e9-4915-a190-ccef0b2404f2,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+76c871db-6b8e-40b7-904f-b4e7f5c89957,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+7718c7e8-bf3d-465e-a92f-91ae875d357c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+772b3452-c63b-4aa8-9f20-528e776e6b79,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7741dff4-7579-45c2-91ea-5d8247a75ddf,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+777e5e3a-5f2d-4012-a4e4-0ee1f20f4249,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+778de925-454e-4f41-ba44-7b97d93e6f1b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+77d2cde0-b092-4d7f-b0ce-6b6c42568169,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+77d57bf8-1431-4268-9148-2bbfaf14fe02,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+78005341-40ec-4883-9025-bc2fc0cc0690,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+78121035-4ff8-4b73-84f6-fe8e0b25228d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7824dc88-5905-4880-9aef-894d2a0c9213,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+783986d0-d23a-4e1e-8e22-b7aa3858e315,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+78433da7-3606-4d24-84ff-1c38be83d6bd,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+786ae4e0-4cea-4b81-9fe0-701e6a74fe7f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+7882aa07-ec29-40c1-b153-69d79404a3ba,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+78f83637-2dce-485c-9bc7-6b7ca0458211,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+7949b873-7b55-4345-b468-b5a35032f938,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+79634112-e581-4378-b899-35b9415bddd6,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+79752a24-d85d-4a92-a732-3a8c81845410,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+799cc72e-33ba-413a-9710-5678296db087,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+79c2922c-575f-44ff-8b89-bdeebb685942,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+79d9477e-3f2d-44b9-a15d-7c357105950c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+79fedcc2-6c21-4092-9493-47e1d00bd9b7,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+7a17eaaf-b8d6-4b89-952c-88cc8cc2aa65,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7a2117c2-d7f8-4f98-ac2c-dc0eb9cfd92f,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+7a3133da-707d-44bb-b139-498963974ffd,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+7a31c8b0-a9a4-461e-9fab-d551823a955f,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+7a68b71b-363f-43f5-b87f-eb905f5c17e4,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+7a7fea70-fa53-4855-ad59-0786f97042dd,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7ab6f738-2b93-4a3a-b767-2a5d55c3e008,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7ab79885-4c2d-4d0c-a2da-4dc20d1d1223,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7b0c2d36-8711-481c-9ff1-82de36bb70bc,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+7b18bfaf-92cc-4c77-84a4-14132f7650c7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7b2ae2d2-6535-4414-9023-52047f232e90,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7b35afd4-0778-40dc-a117-5c69ea91fd66,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+7b49f66f-ac62-4ff3-b77b-dc82459c31d6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7b4bcf94-d267-4581-aa2c-d6e39f38aa1a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7b5832df-b63a-4200-8db6-0228639cb651,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7b6d19a0-b688-4961-8462-92e7aa3bf534,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+7b88d608-a828-4622-9a37-c0d983f45b6d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7b90b7ea-668b-4be4-99a5-5112e6c42808,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7b9c76e6-6066-4d9b-a55d-3b9301c5f321,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+7bbe24b2-a062-4b17-9436-426db22365c2,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+7bf84e56-bf3c-4db7-a488-95a109d71ebc,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7c30b3cd-2949-45ce-a9bf-3b3dfbd96685,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+7c39f72a-206d-422b-804c-874853ecbaac,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+7c43e583-fa43-4105-8605-5518d1bc3642,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+7c50692e-2c9c-43a0-a6e9-2470ad7edc0a,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+7c63e312-1eaf-415d-9cb4-adb586c4e4f3,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7c8c439c-46d6-4fcc-8a83-3f1edbc67c87,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+7c965a7d-1102-48ee-a533-fd994151a236,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7c9bcf50-cc0a-4caa-a30a-db305fea4968,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7caeb2f9-12e2-4abd-b8cb-79c535b6509b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+7cf37120-2fa8-4c93-9620-c5285f907bda,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+7d1970b7-e41e-478b-b386-18955cc71f87,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+7d2deae5-26f9-4326-bdcd-ca7cf8039125,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+7d32c2ac-ef5d-4c79-8a54-cd66d5f35e2f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7d46ad49-1656-4799-99ae-ccd0c1dc157c,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+7d74774e-c5f1-4e64-8397-893fed24d94f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+7d791f2f-606d-422b-a0dd-613111ee8b62,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7d836f65-733e-4d2d-bc95-e7d9bcbf2c19,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+7d98039c-f5c9-4f6a-9f41-f30e0998b4ec,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+7dd35f0a-7d38-48b2-b4db-306048c5e2ff,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7ddf9cb9-46bd-4e53-a1f3-e2288e9f7219,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7e01163b-b2a0-46ce-ae4f-aca0c4cd10ae,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+7e016e85-5f2e-4582-b48a-e5b68a829191,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7e0744fd-5f6f-433f-8420-7fe307352fbd,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+7e146280-7cf7-45d7-b966-a75a4e12304a,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+7e524ace-7712-42d3-bde3-5ab70009363d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+7e52893c-f28c-46af-87fc-544e8ef9379b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+7e75c68b-d400-48c6-945a-86ea10ceb35e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+7e9aff43-8afc-4334-8aeb-4956557a0e45,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+7ebe2a68-d73a-4cd9-9913-efff5bfcafe4,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+7f2f57bb-c361-4cea-a632-e1a309b763f4,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+7f489828-5406-4f71-8de2-cd81efe7dba3,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7f6ad716-35fa-4e0c-a812-89119bd4d9d6,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+7f8dc005-e2a9-4ac7-a6ec-3eafc1a20eae,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+7fdd1998-e3a2-42fc-87ec-38cf7173a9a1,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+805aa62d-e284-4b24-b3dc-87b80b661642,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+807b2b63-abd7-44c1-ae28-a80ab16ecfac,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+809980b7-2e31-410c-a1a8-7c8fe0e897fa,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+809c4f1f-f8cc-4538-901c-d0019e62b5db,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+80b09a41-e70b-4485-8fd8-4afee95c03b2,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+81135718-886d-4da1-b193-20b3f7c027b0,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+811e69bb-cd6a-4528-a0cc-0d2c87894bb3,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+8122d29b-8a24-49e4-8afc-13761dc91541,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+812f512b-85c7-489c-85ef-d700f6eb18f7,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+817686ce-f082-46ed-acaa-3ad2bcef96a9,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+817975bc-f0b6-4c65-8d97-9f13db65cf7b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+81a34655-7608-4b21-8c51-1e14db158a30,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+81b2db52-ddc4-467a-9687-5ed4d8e504da,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+81c23438-5400-4e0c-9c0f-d750fb916e56,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+81ca1bc3-f494-45c2-a91c-c00073abfde0,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+81def6e2-7d47-413e-aeb7-65038448ed96,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+81e3cece-63bb-4baf-98e0-bd5b3dd783d8,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+81f3b054-cec8-45e8-bd79-c88e83cfca6b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+81faa8ea-885a-4db0-a17f-260f38683367,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+82455e77-09a4-4b33-a1b2-5d3a00a6c681,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+82750e49-49ef-4cd6-ad28-1039159bdf68,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+827fd831-c703-4b23-ab7b-12cdb4985323,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+828db0ce-4454-4d90-b997-bd261591663e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+82b44357-95e5-454b-ba9f-71595853ab1d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+82b8b30f-933a-4970-987e-078ee8a42b6e,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+82e9a984-0dec-472d-bcd1-ea55d91e46e4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+83005521-d7cd-4862-9198-a77a2a42c519,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+83377248-196c-40a6-90bf-7dbc39e2b093,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+8340680c-14af-4d11-94f4-95c1d2996e7d,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+83425f49-c17b-4213-84de-14b9fcb1e3a7,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+83643827-8ae2-47f8-afe7-5cf2bcaeab23,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8377ae70-2f37-4704-b9b9-be7b767df05c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8396c2e1-7a30-4972-9bcc-14dd652ca9e9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+839a0386-6e6a-4a71-ad30-4fea13ece256,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+83b38f76-2a12-4ca8-aaae-7c5d9425a3a9,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+83f0f989-4b67-4867-a5dd-8154853defd4,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+83f2c045-f488-4fa3-80fc-242a06998a28,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8420dc6b-0de2-4487-bf88-e7e7c6da2901,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8456c26f-43f4-4cff-9c35-492421205c6e,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+8457d688-5b91-4ca9-8964-12469e650492,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+845f8c0a-b144-416f-8235-c55ee143f8fe,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+846f531e-46d4-43e6-99f1-2b5720520801,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+84c8128d-39c4-45a1-982a-d3e769e930e2,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+84df65f9-62ed-4879-9585-b97cd21c209b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+84efb024-26a3-4ca1-84d9-7bf6098be884,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+84f7e5a5-e344-4050-807e-960fd7081bf0,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8500ee94-beff-4aa0-bd6e-f743bfa03f7b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+855428e9-3bce-47c2-9538-d704abea039c,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+85ab3e71-ecec-49ad-b3ae-32453a5cd5e5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+85bdfc8b-56da-460b-8d2b-8652bde06c37,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+85f42d6f-8c56-4ddd-89f6-9ea572809862,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8635cd8a-5d6e-4f70-9d8a-c4eab105f49a,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+866f41dd-ec90-48fd-bfb0-c155d6ffb12e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+8685b318-c73b-4690-b36d-da0d3d73dc39,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+868e1826-6e18-466f-9a59-bb2c4ea3f456,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+86b53477-045f-4b87-8233-b28739051082,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+86c5a52b-7301-4062-b923-f405dc64b431,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+86db4aee-c4b0-46b4-88a1-1fa7dab9847c,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+86f12d00-b408-488a-866a-7d52256eed49,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+86f7fbda-2e32-4dbb-b93d-84485952234b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+86fdbab6-87d3-4137-bb6a-439c6ca91591,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8709bb42-c665-45a2-a7ea-a4871fd74330,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+871b1098-7a3b-4d0b-bdc4-6e257b51a226,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+87231c8c-93dd-460e-bb48-7bcbff83b5c0,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+8731a4d1-162e-4de3-a7cf-86ad19e29af5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+873c14c5-c8c1-4a9a-a546-580aee0f9a28,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8760107b-61e3-42e1-8097-ad0b539a6399,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8770cb2c-0e1e-4e5c-bfeb-77fbbc28349a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+87a76e7c-38ea-41c2-b9c0-9f34e398100d,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+88037e66-6d75-4740-8000-b59156f3c776,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+880bacd5-11d2-4ed8-8347-c1b24b321a44,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+882b9e33-cad2-41f8-8cd4-8e00e3ff48b1,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+884d0de9-e55a-4609-8334-8e1ec1b4eced,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8865e2da-8a79-4ae8-b7fa-caffc116df11,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+886c5d81-a77f-436c-bc12-2dfcc9bdb27f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+88977db5-cdcb-4fde-99b9-7c1648b7b97b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+88a80049-d1f9-4d1e-a0de-bfbf427fe9ee,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+88dbb1dc-38a2-457f-aed4-4bab27120d88,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+88e09642-6631-43d7-992e-ab0617efd1dd,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+88fec7cd-6120-42f1-b344-9a4595a19baa,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+88ff6e37-2fa5-48c8-bdc1-8d0ef1035e59,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8937568e-6979-45b2-9be9-c5e8184cddb6,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+8945e4d5-e898-4d30-bcec-880d1c5c2b5a,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+898f2c9d-8100-43a3-88da-447ce7905413,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8998be02-f423-4f62-8a6e-606790bee96d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+89a3e825-220c-4962-806e-084eba93072a,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+8a225b08-2861-4d8d-bbae-84e0bb6e1592,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8a2d3352-603a-4efe-a3b7-626e8660828d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8a362b3f-1e12-473e-a71f-97652643f7d5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8a41d495-0fe8-42ec-9ec1-5846e4140eb0,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+8a423187-b556-47fa-bee1-25a4891ad953,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+8a7bf39e-8537-44b3-b438-59b3724af2a3,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8ad55dc0-3385-42ee-b27d-a0557668df4e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+8afd10ba-8529-4ddf-87a1-488885196ca1,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+8aff5ee8-c0dc-47d5-9105-6ab1133b93eb,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8b10abf1-6a49-42e7-98b0-965b527c8ce4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8b6588b2-a168-4143-aa57-9748f80b32fb,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+8b7eb1ec-0a6f-4dc6-b581-65f23196cc49,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+8b8a4505-9049-45a7-a979-036037ccea11,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8b99ea19-182f-4465-a27a-6394dcb47ca2,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+8b9c504c-3971-449b-a63e-ac3d98730d50,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+8bb1ab6f-bf1a-4591-99eb-eee4e7486fe8,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+8bba2011-d370-4a24-8955-49fb2f54f2f0,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8c2679ec-f516-447c-afea-1bfdb21b60ca,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+8c764405-a1d2-4bbf-aed6-d0659fd605d4,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+8c8caffb-ebc1-457e-9b45-b98e08666536,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+8ca5dcf0-adaa-4a2f-b712-bc0fbe64f3fe,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+8cae41f4-0b31-42d0-ac87-a485480ce6c8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8cb0fe4d-dc51-4aeb-a6f3-63c8209a81e1,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8cbfb5b7-24f7-4df9-b5a6-0d9ba7d38d29,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+8cc0b82c-d663-4971-8b5d-c6466316878c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8cca8002-915d-4ccb-aa97-9cb6ca1102f7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8ce05b47-04f9-4970-860d-0fc47af3df89,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8cf14b84-b4dd-4ad9-899d-3f7112066146,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8d0aa5bc-c0fe-4074-a239-1de5bb6e0f82,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8d81672c-5861-45f3-b345-bb23f8c1dacd,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8d913be6-2a3f-4fa9-ae4b-746e29e401f7,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+8d96b7ae-3de7-42ec-930f-6a7e0d07e963,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8d9fd2bb-d9a6-493c-8b49-0f1260f2b2ca,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+8da9377b-f98a-4634-a5fb-194c4b432afc,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8dafcf49-8481-4182-8657-2c7433f70f61,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8ddb82cd-e71f-42dc-bf06-78f6b514f298,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8de74b71-b7e9-4780-9bec-f827398277fb,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+8df01cc8-fd34-4c58-96dd-4bd68bab05ee,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8e0375b8-f71c-4f95-9841-198b9b2af3d8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8e31b895-a5f4-4494-a700-d22b06e82bf2,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+8e923a04-c265-44e2-9ce2-b79c56c2315c,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+8e924a77-94f2-440a-8b87-eb2c1f72062f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+8eb4ddd2-ce99-412a-bb39-c78700e39c0f,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+8ee43a96-df9e-494f-9cf6-d05770a29b17,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+8f134829-5fcb-4da0-8be9-837e6424df8d,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+8f1c87ea-b0ab-4bb6-b0ff-be662289e4fa,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+8f45035f-1035-4195-b144-a5fdf904291e,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+8f628387-3091-47db-b810-91eb3538f224,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8f921551-fae6-45c8-bf98-fe1a25ee008d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+8f9d87dc-60d1-4991-889f-0bcc2c68c6c7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8fe0b3a8-a96e-4d81-9ca6-4975065aa9f0,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+8fec5533-1b72-4cfd-abad-be03193d1ea6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+8ff7622d-1ea6-49c2-9371-2d29ab696388,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+8ff86592-ec90-4b93-bd10-6ee0fa0bfb66,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+90013713-9bb3-4b78-af37-192be218be70,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+901d1fe2-d513-44b0-a665-88cf690e6f81,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9035d5d6-5e77-4ea1-b197-4f172f958571,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+905e96b6-5580-4c44-a3b4-7945e02a9c4a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+90786245-b911-4c2e-a657-07a587464dd6,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+907ac2d8-2ae2-4ae1-bfe3-83e7bb101da8,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+90a471c9-2d56-4367-9056-cd7ef7d1af91,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+90af233c-52d1-4c7d-819b-ad81c4b2cb9d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+90c4b5f6-5bbb-4260-ba46-fd3fa551f647,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+90c54cec-ed97-4b6a-9c54-5edc2ba1f893,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+9119bf42-2c4b-43c8-9f46-2cb0f65a4155,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9129d085-ef24-4a95-9aff-c78c5435523e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+914367b3-dd0a-4f9f-9991-f8de3d827fb2,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+91545930-4efc-46cb-8fd6-0729936c3f55,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+917c5ef9-68b4-4a3a-ac2f-32ea66c0a808,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+91a45bb4-983c-4c6b-a2da-834c286a9e10,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+91db354e-cf61-4b24-80c6-8f25cf24412f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+91e35890-45f6-4195-b813-e57131556448,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+91f820de-644f-441f-9af5-179f29bc4ca4,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+92628e85-13b6-4a21-8c13-7a254b374eba,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+92666b28-9216-4ad6-9d08-d5de11a78019,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+928858d3-ab49-4614-8d25-1bd9406dbfbf,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+92abbd2b-2121-4ad6-90ea-14fab77b5c19,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+92ae0eac-8c7e-448d-9b6b-65ab11f903e4,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+92bf530e-e93e-4c3a-bf3f-f4fa9288e59c,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+92cea34e-35ea-4e1a-beac-79afc97711e9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+92d2b29f-47ab-4fe7-ab82-62807a0e7108,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+92d75f9e-f5bd-4173-a53b-40d51418f1ae,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+92ebfb74-c91b-4543-b818-c507d5f2bee0,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9301df23-bacf-4078-8ed4-f5401ca8d3d6,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+9310edb3-fd07-460e-8aef-77fc4f009807,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+939848fd-d3ac-45a6-81ef-d39522f80083,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+93c6b503-732b-439e-a083-4d1f9c09af68,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+93f16d5e-bf0f-4971-8791-dda33385ab4e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+940d0e38-6d0e-4b2f-bba1-74e485ece699,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+941c3a4a-c945-48f3-9790-a0b1d0f62d4a,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+942ffea3-ba87-418f-928b-6dab0cdff82e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9430f911-57b8-4c53-bd9c-e1957f65fccd,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+943236b7-c396-4bc9-81e8-07ad3897b11f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9432ce80-fa20-4ec2-bb9b-a972d81eb65d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9480b6de-62f5-43bb-a8f9-311f902f7278,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+9481a266-36ba-425f-830e-dcc4c70ed7e9,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+94882cf8-3d17-47b8-8a45-1d3e07396276,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+948cf89f-13d1-4979-befd-cad93c8d66ac,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9492ae0d-776d-48a4-9dc6-ac8d140b8659,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+94941fe0-ccee-4f3d-87c0-d323169506dc,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+94dcd7c9-5305-4525-bfc3-1976088b5827,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+94e9b875-eec9-43e1-97b8-12507f3ef4bd,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+94fc7887-61c2-4d89-b588-cc7a91728196,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+950d54d0-0994-48c9-838d-b8dba9f216ad,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+953bda01-9dd4-4561-8101-4e00b3ac9a6f,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+953f30ef-a94e-4f51-b8a8-fae085ab91ea,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+954f43d1-61f9-496e-8a5a-ee0dc302a248,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+95539df5-6854-4ffe-801c-6c85f756d4bd,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+955ede9c-fa22-41be-a0a5-c8fb750bca4a,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+956bdcfa-956f-4500-90ee-432e705ebc9c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+95784cb2-c76b-4cda-9000-f352efd1e41b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+95d26820-2452-4b58-9c8e-0e9ff54ccc3c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+95eae407-078a-47bf-b579-76af98c81449,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9600e9c0-a67f-4bc6-a0e3-c5bf10b96492,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+961d257b-d982-4cac-b258-6d59b09806fb,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+96e671b2-7c49-4359-b7a7-d2d9d3c5b28a,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+9704497f-0447-4d6e-b9b5-a1cdc3ca35cf,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+97261f02-dde3-4286-9d9b-d700746751a2,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9739a70b-24f4-49ac-a1a4-a53c4049675b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+97486c22-0453-4cd3-a8a8-d1a30531a527,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+97536371-f0e1-48e8-86cc-2d47af051857,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+9776bd9d-01fb-42f8-a351-d48a2cd8f831,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9783bfde-9d3c-47a9-af75-ae0c62692700,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9795d688-245e-4316-bb5a-ee898183c46d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+97a49322-04e4-461a-94b0-d55f8390ba9b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+97c97aed-60eb-4708-a8f6-09c22e960a69,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+98154f86-1e67-4a08-9321-f53b62639409,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+9836105d-3251-4347-86f0-46e1ca60f60e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9886128f-dddc-4c5a-afa3-b3849d60f2cd,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+98970135-6d93-4df5-9e98-473d98ddfa03,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+98fa38e6-ca70-41b0-84ab-fa1ec4f7af92,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+9911f1f9-9b57-4e37-8374-e0139402cd4b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+99707481-ca0e-4734-8106-e83bbe767301,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+998f7eb6-2da0-4310-86b1-8d062cba2d0d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+99a68a69-2173-4830-9403-9c87633bbe10,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+99acb77d-6e5d-4c00-a2b4-aef54f4e08bc,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+99b84c69-b239-46d5-a179-d4fbcf192bf3,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+99c87ff2-6c34-403a-a994-09f85d73d297,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+99ca2cd0-566d-4765-93cf-7ae534eef15e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+99d4effa-35ea-4b2d-890b-2561bcf64004,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+99dcbf1d-f153-4eb8-9dc1-ca136684d434,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+99df1e55-1dce-439f-afdb-a0b4d0d72238,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+99fabe8b-8a30-4467-99f8-3831568a23d1,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+9a0272f1-9e99-4eb8-a227-389567682c89,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9a4638bb-3ea0-4c02-90cf-8fad76a01d7b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+9a581fe1-9c6f-49c2-a5ab-e085dc0be80e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9a661110-442a-4929-98ef-06572cd1014c,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+9a821a40-cd78-47b1-8868-1bca073fac7f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9b1be453-c506-4cd2-8e42-6d25a85aa168,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+9b258bc4-1e2b-4281-8925-d23bac448ee4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9b497aa3-0d44-440e-aa98-37d18950d08d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9b4f5a59-da49-4b2a-bb7d-7e21af7e8113,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9b5f0faa-9c98-48aa-8718-6bb900c34463,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+9b7f5239-1899-42c2-97ae-89fcbd5a9fba,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9bba85c6-edc2-4082-9dfe-8f65af180b82,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9be37b74-184f-4b79-ac43-ac4c9f82a4ea,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+9bf6b1b9-e264-464f-83e0-0dc2cbbd95aa,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9c0aa272-00b3-49ae-8bc2-b1c822dabe17,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9c0bfc6f-3934-4141-a85e-08ec0d696eb5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9c373372-4c72-40cc-b892-374545042041,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9ca004ac-c073-44df-850c-a4ef6cb29156,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+9cb3cbfc-9638-4534-a27f-b4ac1b9b64ff,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9cb463e3-c335-40d9-9bd1-5eb7b00cef92,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9cd45395-215e-4737-9224-7e52c538b267,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+9ce43d17-664e-4a18-a743-bb5ab017ce24,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9d526252-b3bb-4b54-b6da-0df9bc651122,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9d888d4a-5470-492c-8f21-445870cd73b1,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9d933850-3e30-4a5e-8afa-5806b6f630e7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9d98fc34-790c-4a80-a458-4716ec77c534,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+9dce8a46-5535-486a-8479-836a0a53027b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+9dd7a73b-cb6d-4f3a-9dfa-71e3412a62fd,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+9dda9657-9a51-4019-935e-612fa8cc8878,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9e3680cb-2b22-4fd6-b2a7-62b35758982e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+9e54a3b6-14f3-45a9-89e2-66ad7c4b9aa4,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+9e635892-6ae7-4a07-8c1d-1b7f61f12a5e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9e787646-f5e8-463e-a0b2-cb38aeb24031,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+9e84b5a8-f6bb-4d48-9f56-95e1b3860ff2,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9f4f0a07-9a11-474f-bb1b-db45a34dcc9a,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+9f94bc54-2662-4228-af82-67baff6fe0b9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9fbd05c1-20ad-4bd3-9f84-5f957c45e86c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+9fd7daee-a7d5-466d-98ed-de9e7c73931a,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+a007f538-bdeb-4706-b0c3-5ae55d22925d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+a0343d80-2a69-4cfd-90d6-d6aab554fe6c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a064eed0-899c-4ba6-96aa-14c54f3e59da,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+a07a8c61-6c58-41d5-ac9b-f5e3ec36b853,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a09a0dff-91c7-4e60-8f68-9d469f6e7806,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a0b53add-2760-4188-913f-0d4140a9a777,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a0c187a8-0035-4c7c-9be9-fee501cfff5f,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+a0d31ae3-349b-4083-b6c3-4b37149d9110,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+a0d6827a-dcb6-441b-864d-b53ae1b2f372,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+a1332235-ada3-45fa-b42d-3aca9716e5b2,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a15b2875-bceb-4ad4-b708-32e84840cb51,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a166dc2c-f4e9-49e4-a91e-433dafabcec6,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+a16918ea-1edc-445a-9f04-3fc9cd2d2e3c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a16f9676-38d6-40a3-a7a3-610760e86fad,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+a1a82630-d8ef-48fa-9b01-601430258178,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+a1b0c97f-2544-4785-97b7-9fefc63933ed,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+a1d032a9-44aa-400c-a983-67434bcddab2,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a232125c-682a-4a61-ae4c-ef759e52cd7a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a2358776-a87b-4b00-b71d-4f752de83a93,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a257d88d-a4f0-462a-bff2-442925ab1e5e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a25e48c2-fd02-4e4a-aa2c-1e7375d227c5,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+a282b863-4987-4478-a999-349066a2e3c0,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+a295bbfc-2ce4-49c6-a83c-52841e42e6d8,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+a2cd0f71-c671-4259-aa13-657628faf726,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+a2effa15-d3eb-482f-ad1b-5e653f318d43,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a317d51b-ed4c-42ff-8c4c-359d57734ad4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a327afe2-d420-4d8e-af86-20ff96373774,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+a33dbb33-1c7a-445d-a411-24286d6b6488,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+a3500b9b-bfa6-4a9d-ac3e-cd054f6afd45,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a35d1c75-d3f2-46fc-9ffd-35419f7d3390,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a3953efc-7568-434c-9ab6-daf4c8586b6e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a3a36c26-524a-456e-9944-6813721cfe8b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+a3c2f19b-2c34-46dd-a6c1-7b2963618816,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+a3c33d28-7c43-4327-a82e-eb8c3e988ddd,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a3d13e2d-e3ea-4f77-8ed9-f10f0d69481f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+a3d3e672-9323-4d72-ac66-18437b84cac8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a3f474f4-0d88-452e-9f4d-f0f202abbeb5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a41f64a5-1643-48e6-80cd-6651eb7b39d1,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+a42e55a6-eeb7-4220-ab54-f174878407b7,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+a4383aeb-22ad-4921-bcc5-2f5a10aeb429,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a44175a1-1b8e-428a-9176-6d4c70508c6f,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+a446e217-dc84-432a-be06-03ca798bd360,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+a47565b8-dd7b-46fb-ac54-ffa1fc8f65e2,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+a4e73b97-d44a-4173-817b-6705f5f03a3c,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+a510cc21-98e6-4262-9edf-a7a7cbb67eab,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+a5174013-c4c4-42d5-b1d3-84bdd16841c7,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+a52dfd98-8757-4d5d-b0fd-02fe3174779a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a55873d7-4e9d-4358-8351-3e4113f64288,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+a5ad5933-61f4-43b4-9d04-7122121af1fd,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+a5ce3d10-26ee-4d27-a0ed-1057034de0a1,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+a5d7bd1f-f434-45c2-b108-74c56b5f76d6,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+a5f14163-aef5-4355-ae32-a4d4f35c7f30,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+a6137f07-fa41-4b28-b789-daecd728b9f5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a6259323-c672-49f0-94ff-d69dc51a51f9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a634485d-274b-4fde-9712-e6aa7ffc7908,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a6368130-c148-4d68-93a3-d60df7d48c8b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a64775bd-7330-4c2c-8744-853db0caa3b0,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a662e8c6-eee0-4f1e-b361-218b3a23c8e1,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+a6858cef-a405-40c9-b162-ac779b35f9c3,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+a6920b32-6178-43b9-98fd-a0cafd44adb7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a69f2698-a4f4-4cb3-905c-3d2623442e4a,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+a69f336d-28e7-496c-b889-2651d1b0977b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+a6a352dc-b5ac-496c-9413-ce19e791b41b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+a6a953b0-c527-4ebb-b984-a0e23700d5f8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a709cfbd-0508-4148-9052-768aadbc49ae,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a7123b01-b760-4410-98f0-ae5a01bed47c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a723afce-e2d2-4c23-aad9-c2bd8deb4b02,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a737213c-a658-4013-aba0-1558a8a36c5b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a73e26b6-b582-4a19-886e-5806c8be4e0f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+a73fe81f-38fb-4418-8ba3-b2e592d76efa,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+a74a2194-a857-49d5-8bbb-7294bfd824af,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+a75d2818-c021-4161-9e6d-affc2006ba6a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a76f98fe-3495-4c70-a238-670be2fb538d,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+a7830d9a-87d2-48bb-b409-9d5e5d36bcd5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a7c94fb8-0fab-4567-9c95-0a3f134ffd89,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a82bac48-1405-4c98-af5d-c03df73f462f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a87e4aef-a479-4d99-b0b1-fad3458c3f5f,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+a8a27dd1-3f06-4b28-8faa-98cf937b66e0,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a8b0bb0c-f354-43a9-8f18-96b14d0d5457,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a8c91bbc-3cae-4f68-8f4b-77bfbc16de0e,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+a8db72a1-3aba-404e-a6bc-80f2e000c527,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+a8e89d74-1bed-4173-927d-4418b1d132f0,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+a8eb1318-7f73-4267-8302-bc554787a17d,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+a8ef5144-8e1b-47ee-9d01-e32c073a0aa0,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a8fa2a56-ae58-4469-b005-f89e9c34af8c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a9250d5a-a1f1-4f52-8765-eafb70f748fc,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a93936fe-a879-49ce-9837-42f002456c41,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+a952495e-9b31-4a3f-957f-80808422dc64,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+a9bf2944-7dcf-4d33-b391-cc5e8f545d76,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+a9e3d738-be28-4b09-ac9a-61530470a52f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+a9f1e5f9-1621-4cde-b3f2-4b94e09dfc86,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+aa0030fd-5cfc-4d61-830a-5ab67c02b20c,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+aa160846-a731-4187-a412-9975ffe64aad,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+aa64796f-8972-4de2-bec5-facb1ca4ac1a,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+aaac50d7-c7f0-490c-9f6b-ed240e95d0a2,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+aafce373-9aac-4c1b-b83f-250d63daeeb5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ab12aa09-4004-4f96-b2cc-7e49637f813d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ab4fa122-9ebf-42a7-a3de-dce62b77b264,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ab591c1c-b5a6-4fe3-aee3-dff49373063b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ab6ecfbd-7caa-417a-b57d-e80243f91570,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ac064988-f16d-49a4-b773-88479c2d25bf,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ac2c6326-d464-4701-b1bb-ac2a6fed4d61,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ac672acb-17aa-4b6d-a71c-626c80b0935e,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ac9cc0c6-5af8-4afe-a897-aafe1ef48dca,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+acc081ec-0a6f-4314-b139-d756e7d68c99,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+acc66055-f149-449a-9ed6-0a30da2a4ce4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+acc66265-9555-4027-aa01-b7603ba3b3b7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+acd8f183-fc2f-4d63-bc20-8067f0b04736,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+acfff96f-bba6-4f8d-b35b-b512529a7213,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ad2372d3-aa96-46d1-be4b-60141ed1a94b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+ad2b66b6-aef5-4301-8e61-e71f9d0d6007,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ad2bb819-e3eb-44db-a16b-a9ca5bf75cd1,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ad30a69e-d76f-4f9d-b2d8-8a3a0d025e2f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+ad3526f1-da88-4340-b171-cbd9bebf3c2c,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+ad397e24-caed-4e81-826c-35cdd82a9eb4,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+ad57e1ec-5fce-4831-a4b5-2b080e5bcf1c,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+ad5f035d-ad5f-4a96-a261-b92b0b31fe71,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ad6f9e0e-12e9-4b0d-a9c2-c378e2f1e1a4,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ad7384e7-972d-4849-a01b-c21d60de2bf0,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ad73c41f-0a57-4068-bba3-ed88d04d4177,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+ad7f3718-5885-4a97-baa5-e888637a0460,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+ad906439-31a7-4d02-aaa8-37f0c6a322f7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+adb49a47-3eb6-4e11-9ba8-5fa19bd4cfbc,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+add15a2c-fd96-45ed-bec8-f1962c30dc1b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ae053abc-3d47-43e5-ac33-ff1e352e8f07,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+ae14ebd1-0552-4889-84d5-ae0ca1c7de9a,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ae1edae1-5b5b-4a4d-8ac1-582844710b01,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+ae2d9f49-965f-49e4-bf42-0800e7707b13,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ae300054-45de-4faf-97a0-5ce60bb01d05,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ae37104f-0fc0-4b61-8738-0afc2e050bcf,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ae375193-986d-490c-8e5f-00c1df4ea12e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+ae5e652c-2c43-49df-82bc-d40a19e002f5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ae9e775d-1272-4b0c-ac5f-38271df8d68c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+aea1a253-7862-42b1-8c22-0ccb1bcda595,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+aeb68bd5-81db-4e88-b67b-5e4185d4bf81,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+aec5b5b0-4661-4cc0-9a31-031131bf0491,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+aeda93c5-b6b8-4cc4-99db-458046347efb,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+aefea66a-08c5-4f4d-809d-fe7f15c8a9bc,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+af2b97c8-7437-45e3-aa75-99c6d395795f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+af43ebb4-eed9-4811-a3e5-b8dcf3b813e1,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+af6ae241-1ef1-4b4a-a597-f1d21d368515,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+af70ba27-3257-4d98-a051-64c8e282410e,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+af79a2f9-bc7d-4d78-917c-ff8bc216a724,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+af80162c-64b5-4a49-8952-cc591ddcb6cb,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+af8876e2-123b-48be-9e60-fdadddf7d275,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+af8bb43c-26d5-42fc-a391-7245b67995f6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+afc340e5-1889-4cc5-a7f5-d360e4d400cd,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+afca3b70-d297-43aa-8d15-6b76376987e4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+afde3c3b-ec07-46e2-82ff-620ecf9cf8d2,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+aff48aef-9bf8-40d3-a2e8-3636a144272e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b065f6ff-9a52-4853-bff2-047ede9a4e24,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b0709180-f408-46b0-bf34-dd542bd62af4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b07135b7-f8cd-47ec-89ce-ad3c700cb4ab,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b09327b9-4860-4f8a-b689-be51314cfe26,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+b0aa25b8-e940-4f7a-9cd7-2f7c5058bd7e,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+b0cb7dea-5fd6-46cc-90eb-661b66aff9c9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b0df513a-eebc-4423-85a8-46655f126bf3,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b13b9531-d219-4380-a01e-f968e8e097f9,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b1680dcf-842d-4fc6-acb2-80bf74f30691,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b17fc20f-f84d-440f-8e5a-47486afbfbd3,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b1865def-c1b0-4589-a490-5ae91dd6b168,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b1997a00-e493-4e95-88fa-d80e48fa3a33,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b1c97cb1-ab62-4117-9f91-f44a73809b1f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b1dd3ac8-9bea-4350-a504-9856b5939b66,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b1dd8222-5e6d-46a6-aeba-857fe770b289,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b1f84378-4eb9-403a-bf6d-d4fe13d2e8a6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b21c6426-d55b-44d3-8a73-0b12d2acdc6f,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+b239cf90-0948-4166-bb36-975537942fe9,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+b23ff719-beac-4d72-b6b2-329ab4c72e30,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+b28985e9-d007-4265-b559-30259af2ee3d,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+b2e328d3-42e8-4521-9353-6b08ea2b70ac,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b3383709-1e43-4d49-a665-be7ca083337a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b34694f4-0b25-4fcf-ac10-099f1cdcd5e3,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b354f111-0d43-4342-8a2d-cddf21605c51,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b35dacaf-bb23-4c44-ae6c-681a932bcc83,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b37b00d1-a295-4294-97e0-62461454310f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b3b1dc68-912b-4381-a97b-d3f56afca9a0,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b3c77cfc-7a5d-46c5-8743-e4a5a15c32af,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b442974f-5ff2-4c2e-8fff-e4f2913d9dd8,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+b4437a1a-6975-4e5f-a236-41c9dc14c787,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b47c5b8c-0f12-42aa-8e3e-9ff5624dad3f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b483099b-d822-443d-8e4d-e5419d7f56d1,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b4a00276-ab46-45ec-b2e5-bc78fcf12060,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b4c0cafc-050e-4d43-bcac-2029093872f2,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+b4c12bbc-c43a-4032-a368-9bfa4610815d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b4e4d0d2-40cb-4fac-a30a-3d4dc51f7b0b,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+b4ed446d-1947-469d-8396-09df6d031d35,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+b50a8363-2d9d-4f47-8ac2-67ea4d83e97f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b52d7a58-b48b-40b2-a911-480885cc6707,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+b53e2c77-c328-49a6-96cf-e7a7935a6b5b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b5435db8-6a75-4c6d-a9e0-048e9507a28f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b591db08-908b-41a4-a614-65a7e730c6e6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b5bebac6-9219-4969-85fe-5ece4ee03380,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b5c98c81-5d35-4f3c-a875-f8a4d2befca7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b5d4156a-62da-4c82-9b7c-060ebc7a6c23,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+b5dd9c4c-952f-4ed6-b905-809a286c9229,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b5e93050-8908-45af-8a09-42603a2923e3,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b6049d19-65d1-462d-97bf-e2e79e262b6b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b62c7097-4839-48b0-a04a-73d93f9472f1,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+b62d18cc-231d-42cd-b3d0-826646f0e218,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b636ce50-952e-4e25-9276-940b462084a7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b675632f-e9da-455a-9286-2230891fdcf3,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b6b57120-939b-4708-9151-a39a9ba91e13,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+b6c4db6d-1332-47bb-86b8-19cda305ef63,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b7090885-e1d3-4fe4-8133-a29ec6a16ded,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+b75aa49e-dc4d-4e56-9a94-a2751a64c309,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+b7b8b87c-6c59-4074-b72b-86d3267e9ff9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b7f39041-28c6-4aa9-b87a-6f25517ab244,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+b80bc654-53a8-4805-89b7-cbf228a82c20,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b8375416-6e85-4556-9ebc-992f1a8a40ec,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b84facf9-b3c2-4e78-b679-486ca09f298c,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b85057d1-91d1-4b46-b456-de1a0d4d140a,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+b86da8f0-58b9-4f4a-86ba-4ab8fa859983,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b8a09772-cae7-4280-8d61-6f0e68576647,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b8b93009-01d5-4e8b-ac0d-c7b49f358bd1,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b8dcb46e-34e9-487b-9b36-432af3d52ff5,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b8e2d9bc-2511-4378-a096-abbc79f5c423,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b90615f9-ff62-4ca6-92a0-619123b8c155,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b9106cf0-5703-4e64-bceb-f8718a932773,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+b91b7936-1464-4ff6-8c62-438ed2e2120e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b92c2398-5d35-426a-ba1e-0927ca5bda8d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b9305aa4-b087-43fd-acb6-2962ce820e81,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+b935f443-51d6-4be9-b96f-bd9c4bef6c22,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b95d49d8-79ec-45d7-9e3e-92e0bcfd755d,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+b95df4dc-545e-4c81-9a92-2918d3a46edf,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+b9607ddf-691c-4d5b-927c-25d8de877d74,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+b9998687-b619-4941-8d9e-15ca0964965d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+b9b7a63d-a95d-4117-813f-0dbd9d82a5fd,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b9d50039-e57e-425b-a81d-39f29973a5fd,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+b9f8492f-fbf1-4cf6-8b05-da1fe4e413ed,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+b9fa03b6-8de6-48d4-8a9e-dcb7a7de2f02,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ba04c54e-ef2c-40f0-ad1c-419eab01d4f0,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+ba074256-57ef-4404-bc36-c8afee0cae63,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ba16cd0a-2380-4485-9649-91d2e690de57,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ba3acce6-e32d-4c4e-9243-d79e9a1056a8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ba3eda43-df68-4cda-a670-877c5111d60c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ba48a064-8fe8-47de-84b4-89022174c171,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ba512e0c-7f5e-4558-a363-c1867cf57b21,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+ba635e8e-8544-4d00-83a9-f8caef8c590b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+ba86a31b-19a9-4b35-bea8-6bb203c1f91c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ba9ffceb-3d4d-453c-9c64-6f1942927833,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+baaeb58a-2680-4426-bbff-c1dd704e8b87,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+bac45dfd-76f9-4755-a024-1e199373b656,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bae19dec-310f-4de7-bf23-f90fcb0a1a32,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bae4a435-a783-45d3-8a03-7a2c352f08f0,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+bae899ca-3f74-4db9-9368-7ab9b1975b4a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bb0fbf11-b4ef-4971-bbe3-155cb5f84bfa,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+bb12b2ad-4c73-47c1-85d3-5a9702bafcf0,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+bb21444e-0926-48ac-8868-d6396caea1ea,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bb3db23d-652f-4631-a895-415479e00850,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bb3fa527-7f22-4d1c-a36b-16b0bbe2bc2e,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+bb412b71-c750-4c0a-b69e-77f6eb486adf,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+bb9d3334-a321-4d2b-8e93-2f40059a9858,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bba5a80a-79c8-43aa-8334-2a344b386f6a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bbc346c6-a3df-444a-a0fd-8e439b82454b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bbc36573-3af2-49cd-91c0-4a78794c245a,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+bbe2bc91-84ee-49e8-af48-ffd038af998e,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+bc149d88-af1b-435a-90a3-f551e7922a9c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bc2ad3d5-c213-4ac4-b8a1-6270794b0b54,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bc2fc201-15c7-4e61-9e04-90d2a71ad167,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bc464e35-7a24-4427-8ed7-e003d8dea7e5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bc47740b-6c33-432f-b5f6-50c6277ef85a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bc51f828-2449-4713-8b40-539cc5a7d333,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+bc5f55cf-1da2-4b9c-b8b2-c8115ab455d9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bc643f75-5c3a-4163-95ad-39fb64ac1b7c,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+bc8112ec-c191-4066-a2f7-e9581bbb5b2b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+bcba8f72-69bd-4da2-9e89-50c2ba05d91a,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+bcbafa1c-9441-4a2e-b186-29a22922c22d,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+bcc065ec-2a1c-4cc9-948f-13f47113dff4,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+bce14139-eb74-418a-8bf2-c0c9df60ca2e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bcf527ac-e453-4ae8-80c7-3641dc9a4120,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bcfce4ff-237f-4f81-bc8b-4d44cbfad3aa,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bd2b837d-f033-4381-8de8-855ff1c67956,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+bd2c43e0-3ed2-4922-b3b3-874dae614dd5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bd588361-1806-48f6-9640-09d1ad5975da,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+bd5b6b89-fc28-4e23-a94e-4457d04e9268,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+bda53c9a-2570-4b8e-bba6-60671c3346b5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bdb4c8ed-87f4-42f9-8d09-cfd4916085d6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bdd8f438-f97d-4dea-8316-a9a570721ddc,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+be483a30-31ca-42de-b070-7a2f3508d970,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+be52588d-560c-42d5-ae10-3c972d071f5b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+be54b42e-d4a2-429e-a17a-8353aed2bc0d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+bf04d6b1-2069-48bf-9457-69d413214591,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+bf136f33-2ef7-463a-b164-6b9c73e40d44,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bf2f6a83-2ef9-43fa-9334-3c8246bc0e54,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bf323fae-42b6-45a1-9917-bf58be67db1e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bf4ffb70-6f54-4c3e-9b5b-d6a2f4e44d4b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+bf55b444-ce18-4c10-95fe-5229fd1da1d0,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+bf8bb496-afe0-40a8-88d9-53c78b1a12da,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+bfd61852-6174-44a4-a709-af2abfbed3f0,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+bfdc2bc0-2a6a-4b62-9174-e9f43ea5ca31,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+bfeaf062-83b3-427f-b437-d0b853542297,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+bff5488a-a965-44a5-86b6-0bae1c062150,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+c00050cd-ca81-4456-9d51-7d871776fd53,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+c02a9bd8-d15c-48ff-9df4-8cd6e85527ed,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+c041df7d-0a83-4226-8bd5-db7b5a5862b4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c04d1d29-a77d-4975-a41e-8a336d6625d0,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c0572e10-6bca-4897-b247-602d37a916f5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c0662154-5097-4735-9a4a-cbdce803ee0f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+c075365a-d9ed-4adf-8520-8405cc54e258,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c1033706-8700-44ef-8387-269388ccbd1a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c130b395-4a72-46f9-bae5-06f8dc41a185,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c13e2664-dc3c-442b-a613-3cea26e28d1e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+c16fcc7d-f9c6-4657-899c-ba736c5652b6,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+c179e754-ca9d-42a7-8533-9196dd37c66a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c192b301-e539-4aa5-a488-cdf357f31bc7,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+c1a4b61c-2661-4ed9-bfc5-45676c0d3b85,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+c1b82f86-7b4e-48ed-aa30-eb616ee28aec,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c1e023e1-3e8a-493f-aed2-f97208fd02e0,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+c1fc3f74-7d20-4bd9-8297-796a8dc3df71,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+c2344d99-27c4-4341-bb9d-e8c42da95855,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+c26910fe-5248-4a03-ad19-694ceeaf1d6e,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+c2833621-5fd6-4d20-bab2-b61746cd3e13,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+c2860d42-a47b-413f-bbad-d7dc499c2fdf,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+c2876069-35fa-4ee0-af34-ae39d4b66ff3,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+c28cdd66-d25c-4aa1-8311-4d3b2a2c21b6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c30b18a8-3f5e-48a3-be25-6848e7e089d2,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+c31433b5-9812-46c8-83fa-15410bf77863,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c39d69e2-a3c6-4d99-a4dc-6d06c6ec424f,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+c3aa3f12-5656-4fb0-8ab7-8780b5167d00,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+c3dd3bdd-c2f9-4868-9ee6-46c1ba4527a2,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+c472d934-1e79-4368-906e-093e809d61fc,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+c47e7c2f-a153-4d8f-924d-a4631a8e890a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c49f7ba7-379b-49b5-816b-0a43efdc5500,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c4cc308f-5eb7-4d56-9539-119c2e48be5b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+c5169184-1b5b-498c-a219-c5a235d6acf8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c544cce6-c69d-47eb-862d-8624f6443710,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c579be0f-7556-4400-86ce-a675ebae9140,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+c579e08b-f3d5-4184-a195-4f9d373bad66,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+c57d5ee4-c25f-43c6-9266-829f5e745198,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+c57fd5e8-0dd5-4d00-a786-d9d3e78f9fe7,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+c582c530-e3af-44e2-ac71-9182a0f0094c,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+c598f18d-585c-4afe-a674-5fb4d2ef5f92,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+c5f8bdc1-1490-4d4a-8c37-5229379ffb3f,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+c619ae69-1a0d-4f7b-9e70-f6bc4f738c68,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+c657319e-2d80-47a2-8d92-b665cf2791d3,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+c6bb2780-adfa-4fdb-91c4-fea69c73a4b2,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+c6d7ebb0-f5ca-4bbd-9f4a-27c94f546f6a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c6d910b1-177d-4fb2-894d-9ca637a6282b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+c6f06998-f692-4dd3-8880-df62ce6ccd2e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+c7033d15-f63b-4b39-8725-dfa0a1f41d5c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c710f45b-26ad-4b7c-a3f9-93b67334219b,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+c7161fe8-4db7-45c4-a375-4abcce29a4d5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c723ab2a-5910-46af-9f6d-247b07953180,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c72b01ee-79de-4071-a377-c892f54b126c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c72b593c-d01c-4b6e-b6f7-18efafd24bee,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+c78a31ca-6265-4acb-a974-147c8925aceb,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c7b326d3-4e25-430e-8746-81abe1176fb5,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+c7e75f29-db06-407e-bf2b-4fe8b393d3a6,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+c81d4c99-4311-4f55-9bca-ac4ac1a55851,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+c87301cd-7680-451d-84eb-02102be1b754,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c8754ea7-af9b-4d68-8019-3ec1826ae271,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+c882874c-259b-4d64-b184-5e92e5dee7d5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c8905bfa-b299-41cd-9e6d-612fa698601f,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+c89b0839-770f-4a2a-8b4a-816f7d75b461,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c8bc48fb-134f-49d5-9d64-5e50e22f3447,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c8c2f224-26f4-400b-b902-46508fc017e9,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+c8e83c39-b0cd-4f69-83f5-adad587dac8a,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+c904822f-7539-430f-bec1-bd9176bf3935,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c92c73a9-dfcc-4b10-bb35-34646dd68441,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c931dc2f-c217-4d43-802a-d32ba91182a9,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+c93224fd-6fd4-4849-ae53-d675fb26fdd9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c94b8cec-2c02-48e5-bd03-0c3bf1cf11da,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+c951c906-0378-4890-95fa-3a7d3a0a0e27,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+c97b7b13-c4c1-4748-90ed-2cf74aed7661,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+c9a8dc6b-caaf-452a-89cd-00f04cacf3ba,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+c9bbbd62-33dc-4ffb-a5ed-6197da41265b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+c9d57c15-b996-4a13-9e28-0f4b75941487,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+c9fd0345-2df8-4ae8-b3a5-bec4667802c7,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+ca02bb2f-1a4d-4d2c-93ac-89a64665c9bf,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ca1eeae6-0f82-4a9f-a1e5-160b587840fd,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ca3b3673-cf13-43f4-8fc9-04fe3e880b3c,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+ca48509e-69fe-49ad-b78c-ce846df6de84,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ca4ae636-ca37-414f-9bbd-2f5b959db78e,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+cac502e8-fc59-462d-aafe-d80ee6cd0de8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+cacb7c5d-23c0-4aa1-87de-f4f36e9a7f6d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+cad2f653-dbee-4cca-b374-798338ba7227,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+caebcc3b-67d8-4413-a225-0ef5aac57d20,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+cafbe7df-0025-4efd-b9fb-0cd54d72f4b0,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+cb2c1fa9-3a23-465a-a772-b7647634894b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+cb367f09-fd29-4eb4-8765-eb43779328ce,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+cb4583a4-8210-4b8d-86aa-5ae2cbe5101e,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+cb7fe49b-6cb5-45c6-952f-ae28c21c55fb,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+cbb33a77-89cd-4565-abb5-ed4abcfec79e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+cbef619d-cab8-4875-a9a6-8326b419a08c,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+cbf935f8-731b-4787-a5af-4c740224c147,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+cbfe2ccd-80d2-4084-bee3-bc2c81ab0cee,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+cc0493c0-78ad-496e-af05-6561b6ad1298,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+cc4438f1-3e1b-48cc-b33c-d749d5cc098d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+cc5ff589-4952-421e-9eb4-3d7be32b7967,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+cc72fc72-e24c-41d0-aa3b-962bc1d504b7,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+cc82dd50-5501-4fca-9264-25abd8d089b6,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+ccaba6a4-d02c-4d75-93fa-7f3218453f05,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+ccd2fb31-d851-4b80-9128-4e5d718ba753,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+cce1e597-c798-4d65-bde4-e0c5d45b9301,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+cce44d26-f897-4e75-8517-a17bda798bd6,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+cd5da991-bc14-4ee2-a030-744e4a166edf,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+cd75848c-dfdd-47cb-a851-a6820fd7bf2e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+cdae6200-2241-41ab-ac45-5af58bfae918,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+cdb21a81-d462-4492-9ddc-e4df91815191,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+cdb33470-ffe7-4aef-946b-1fb8ebbe0f2f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+cdc5b3d1-c650-401a-8dad-e9c4cb668350,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+cddcef1c-398e-4343-9d1f-761b390e2c58,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ce02d9da-ac93-4796-9a32-b24764ad452a,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ce0b5f94-ec41-437a-8d2c-3764f383e7ab,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ce2b0f6c-f1cd-4133-841a-c06fbcd17ef1,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ce686e04-76ee-4bd8-a58c-34440664fa5a,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ce8ad2a8-4e81-4389-88ab-e16233889c4c,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+ce8d2278-17b0-42b4-b32e-c4d64dffb954,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ce8da88f-d786-453f-9cc6-73a93911b050,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ce9c6e1a-9383-4bda-a0af-08786cff47e8,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ce9e9361-e537-4616-9376-a00916d8ee4a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ceab7177-cd63-45cf-87e8-b9f89cf77cbd,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+cedb9e17-ed79-4f9b-a616-e160299c534e,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+cf102987-51c5-47f9-b930-ed4c034c5e2e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+cf36a57e-1cea-4d9f-a346-e21263ec0c1e,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+cf4c6808-6d42-4c2c-b936-efc0db8477f1,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+cf62828f-9810-4459-9ae2-2c686f082c53,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+cf632292-ea4b-4bd7-b3db-af10a129a48e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+cfbba82a-209b-4ab8-b57f-803d46d824b3,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+cfded97c-ff69-4798-adf8-5fd53cece148,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+cfed88c2-e9fc-458c-8408-5ccf08e6315a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+cff1db54-698a-44a6-802b-fd1a036e08e5,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+cffad503-bf2c-45e8-a5ac-f78cbc5f546d,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d049af3e-e04b-4c2f-8be4-ff392503d9e6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d05a98bf-09c6-40a8-9b54-197bdd95cc72,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+d05b00f3-647a-4691-89bd-1e5226194ba7,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d06671a5-5fe0-4a85-9a8c-c3eeccf1f3c6,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d06da220-63ce-4d35-bc6f-7345a7cf34b1,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+d072a56a-9f92-4ec7-a54e-002a06d29166,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+d0784a3c-fbce-4671-95bd-727df873e0e4,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d0945a51-5c3c-43ac-ba8f-bf858c303263,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d0962d42-7cbf-47a6-be34-0633cbcd3c62,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d0a9f854-8819-46f2-a1c0-be755cdf2c72,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+d0b4d9b7-ed51-41c3-8ed1-b8564c8b5103,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d0c641b6-36d5-4fcd-8856-6d6e655b2a0e,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d0fcf085-5aca-4f7d-9e94-a4b06c45b824,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d0fe5fc3-f432-4f3a-b1d6-4318fce39956,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d10c00de-81ba-4c08-bff3-03413874ab88,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+d12b6d9a-74cb-4670-af33-86239df9fc96,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d12ce295-3ff6-4e76-ae22-3bc4e23ae2d5,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d14f8156-d3c3-433a-8041-2cdf645e4893,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d15b3b24-1f53-4fb0-aebf-426de685ab15,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d167e8d9-056e-466f-abfd-2fc8bfcb6f04,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d17bdde4-3307-4b47-b598-902df26213fc,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d18f9a8a-90e4-42bf-b54c-7c5e1b4b5689,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d1a687c1-71ab-4d09-ba12-7043e402b87b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d1b71851-b8ea-4d97-82c3-7cd17d5fc1be,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d1d3e404-fa87-4451-a09b-429045eda748,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d1da50af-acb5-4c7e-aef2-9fb522370d56,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+d21a2a44-5d04-4acb-a187-22d77a4ed2c3,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d233e364-2ec1-445e-9aeb-95706e6e8674,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d24636ab-c98a-432e-9eb0-f35a42f417fe,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d249887e-7170-41d7-8596-181124f45c13,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+d2543d44-bac5-4667-9f50-adb80f6d450d,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+d27db708-776c-40f1-aa2a-4ecc341fa7a3,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d2b42082-f842-405f-bb8a-10ea01968f2d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d2c583df-b8da-4c0a-ab9e-985289956b03,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d2e85d7d-b5c4-42bb-82dd-d9888b6dad28,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d2eeece7-f141-428b-a597-2261a388ccd8,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d2f0ca48-b6c5-4d2f-aba8-bdc4830c5927,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d32bd8ae-4b2f-48ad-9084-9c1a79d405ec,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d331d352-8483-44fd-b4b8-2f575c891f03,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d33729b7-fa8b-489b-9ae6-551ef7a2e4a6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d342ab5e-e7dc-4101-934f-11d74dcc94b5,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d3436526-8364-45d8-93e3-effdc4a7f5e7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d3679ab5-2c85-4f69-a29c-ece54ed8add3,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d381d032-b276-4ab3-8054-90bbcadf8c3c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d391d380-85c9-4b5a-9f3b-786768dd7f76,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d39c8b78-d9d9-4c45-9446-bd5bc8365bb7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d3aa62b9-1600-47e4-a54b-b273cb90c977,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d3dbfb72-eeea-4c1c-a2c7-6aa1c1a007f1,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d3e19da6-764a-49ce-b070-72d604ad4c50,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d40c837e-289c-4a54-8650-f9220ff014d6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d40f75f3-01e2-4c8c-9766-7af5ceeaa284,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d438343d-5a32-437a-8405-61aa193fda27,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d45303f7-9809-4513-b37f-9db82abbc1d6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d456d434-ad02-4ecd-b74b-7451aaf9f09e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d45eb0c5-3150-4764-a75d-da09b7076cfa,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d4798ad2-761b-4c73-9d1e-6dadfb2aede6,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+d4aae346-602f-4639-82e6-65cf43e74697,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d4d6f51d-e48f-40bf-b460-2eba9f0acb03,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+d4f00ba0-0642-419e-b482-dab79176216d,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d50b9fb9-853c-4b60-a501-68a9522636fd,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d520d87f-833b-4bd7-bc28-3c9f6dd7e514,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d52e95f2-9a79-4d21-9f3f-2822807f8081,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d531e5d5-7d36-4780-aee0-234da37ffb99,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d53841f4-59cb-4a58-9a8c-123e7bf9f2b9,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d558edb0-2fea-4b89-83df-61c3874e946f,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d58f4350-8d56-42d8-9b86-79aad6dcdb86,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d59f9eef-c33e-4749-bae9-b00e606da8cc,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d5b67a4a-13df-472f-b049-27fbe4f2e5e2,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d5c47379-4921-46f0-8df4-988d2c988c13,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d60db77f-8978-4216-a26a-48b48a2c91cc,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d61f01ff-fc5a-4143-b5b0-f46f29024919,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d6474b45-66b7-4915-acae-979d3064e68a,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d66cf08d-1b07-4d64-9ef3-615f16318989,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+d67e347e-c196-4e34-b3de-67f6531aad1c,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d6d5d897-6f75-43ef-ba5d-e0b042d84bd6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d6da9ba9-5b45-4713-99b3-4b948f6cd065,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d6dc6560-bb61-4097-b92d-50f4b96ae5bb,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d6ea1d0f-82d0-495a-8d3f-389b3e6c66d1,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d6f7d193-1a40-4fa8-a6c2-157019095044,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+d7274961-44cd-40fa-86b5-5f0d520091ef,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+d76ef0ce-b294-4746-9634-517966aeee06,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d78c2635-54e3-4539-b964-54318b92639e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d78fc312-bff8-4f07-b0b5-7fa94d9e1e64,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d7b696eb-fe04-4132-9759-e1f279cb16b7,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d7ba81a6-23f9-4258-a55e-0c6696bc8c57,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d7e2a3d5-6b94-42ba-beba-840bdc3fcc17,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d7ee21ed-0963-428c-b490-c82152949735,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+d80f8e20-9a04-41d7-a06d-7b3697e11208,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d81ffd59-e282-433e-b494-4cbb77f0efa6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d83f5a19-b89e-4e68-9b62-9030e56804a1,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d855e6d0-9a26-485a-87d4-2f63aeb8ad7e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d865fe9d-cf60-4251-99ec-27fad596fc72,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d86da66a-4b94-40ec-928d-daa356fa12af,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+d89252b2-167b-4129-8bc3-57c58f0a1c67,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d8965dea-c65c-46b2-8d85-5a53e84de2dc,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d8bbdc41-a959-4e15-9fe4-f6ed1a552006,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d8c15dcb-197a-4bad-b356-1310def58e40,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d90d17b8-3aa5-46c9-992b-b9d4347df8b0,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d9356ab6-bcd7-47ce-a588-994d72072d97,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+d93832eb-0c9c-430c-871e-26fbbc2ff1c8,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d9646619-42e2-4c36-b827-fbe83831b3e2,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d97842fe-ff1b-4e40-accc-b8b190c3b427,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+d9bc0dd8-0000-4acc-9024-a9f80adef99b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+d9dfbcc4-de76-47f3-8f4c-b09eae74d99b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+da0d4e6f-459d-4da4-8623-02b21feb3b02,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+da6ca634-e5d9-4c4d-9d2b-526e41c97bff,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+da8e6812-7ad6-4a77-b7e2-eaa97a5da483,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+daa09b50-d7b1-465f-a864-8e5758825fd2,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+dabdc9ba-d935-4117-b007-f053f022d046,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+dad244e8-0069-42ae-9f72-e76fc07678fd,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+daef3eb0-76ca-439c-a217-8e2a59c0d456,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+daf6dbfa-8f71-473c-af41-303919ddd555,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+db4a06f6-ce0e-470f-8531-a04baa00d1f7,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+db50be34-720d-4341-b837-37c0b066e225,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+db51c90a-bea0-4b82-b55b-eeba7bde2e89,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+db526f35-e886-4b28-ae33-36b5101248b9,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+db527b0d-cf5a-4abb-890d-823b57202641,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+db5ab85e-7ea6-4930-989e-a864af2f0abe,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+db5b760c-dcc6-4a06-84fd-eecbbca7d0eb,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+db87a982-beef-4546-99a5-9d9c6395b37b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+db969175-d90b-4c35-b1ca-5475ba782e49,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+dbb40607-f85f-409e-9631-13bbf2f171cf,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+dbe42975-538a-49a0-b64f-2286990ca9da,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+dc196ccb-8b61-4e71-b224-692640088c03,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+dc33d67f-c36d-4b37-ad4f-da47a3f8c9a0,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+dc7244a7-1edc-4948-92f8-ff2290ebddd0,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+dc7ce146-f38a-43f8-b68a-e16211e33430,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+dca8b237-1b7f-4dab-84a0-1c77ac166140,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+dcb438c8-83a7-46a5-b588-e669ab08243b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+dcbb9b4b-d5b0-43bf-936a-2520b802e163,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+dccc418f-387a-45b2-91ed-c0fd8c54c22b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+dcd339b1-df72-4337-a7c2-82454699083b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+dce23fde-b18f-475c-9cee-e452871740c3,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+dcee110d-7cb1-41db-8f2b-a425e45af969,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+dcfa4a78-dd57-4cc5-bb4d-a0eae0c7e67e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+dd2fd2ad-27f1-4844-a2ac-540d1ee7dd18,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+dd365605-4720-4e4d-8c8c-1b3ae8c0a334,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+dd74396d-af6f-4e84-9be1-0519acf1e861,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ddeb8d02-2e5e-4e89-a6b4-3aec3aa57179,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+de0d5094-34e4-45d7-bab1-7ac72f3fb238,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+de121463-5de1-4dfb-ab55-a9f96d8a2b55,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+de2fd7e5-16f7-459e-8854-7a33725c178a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+de4d0ff0-6bb6-4496-9f4b-594d8b55aaeb,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+de711744-4835-46fb-a3d4-e2f1606e81de,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+de7d1374-a92e-4837-bab5-9b5faf5e5c10,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+dec268f2-784d-4c53-beba-fa1397832e05,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ded97fa1-9e8c-4023-ba83-406058b638d3,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+df7b58b0-fcd4-46e9-a79c-1200cb486596,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+df8052bf-7269-48db-b66b-082b25faa3ea,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+df91a590-5b0f-4a02-b3b6-9d2f0c7c7404,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+df9b516c-2dd0-4397-8a43-c988ede096fe,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+dfe3b1ba-e384-4618-9116-fb3eca1e04ab,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e0143776-2ba3-4c6d-b102-1ca2723cf66c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e020b959-9bc5-492f-a4fc-988de6a56ad2,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e03f1554-30fe-4102-98a2-498e8fb3d79d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e07ae53a-c743-451c-a495-e3cb45d4554e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e0805030-9840-4311-a0b5-e620b49bcc0b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+e0dd5295-0516-4184-bd53-b05282e4355a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e0e89188-4d89-4cbf-a132-0ee68a418db3,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+e10b06a9-cebf-4042-bca0-ff7dca127334,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e112c014-cc84-48b9-96d7-255f628013b9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e11d528e-5dac-4a35-b4c1-c7a0b91d56f1,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+e1529649-d364-4469-8477-9b82cc47a3e2,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+e17ba46d-ef31-4447-874a-72bac11dd073,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+e188e759-6c45-4320-9ab1-e3c3458f97e1,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+e18e734b-baec-4db7-851f-ab131f219533,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+e19a83c9-d062-4321-a1d7-79753aa2fdd1,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+e1ac5cb1-f490-4e06-a6ca-189fdc0be01c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e1b9681e-02da-4acb-a767-c9543b5f8ee0,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+e1bfa9aa-1d63-44c3-a087-e98ee5d92bcf,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e1fb7034-8297-4651-8ea7-db4b40f8d2bb,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+e2021da0-7e3e-4337-8f7a-9978eb727c72,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+e225e1c0-16f6-48b4-9588-fe59c20c2faa,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+e23cb465-99c1-442d-b1dc-290d8373e942,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+e2aadcfc-65ce-4c8a-9d8c-c6b4b3803c6d,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+e2d6db57-06ec-463a-93aa-c3ad2bbc054b,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+e2e772d2-adac-4935-88d8-d29dd94bce1b,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e2f6b759-6b46-4d54-95f7-54419d40e5af,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+e3603be4-8b8f-4d9b-bf53-4f2a2d325be2,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+e3b577b6-e860-4be1-80f2-b874c67e8d8a,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+e3c4c57f-7ddb-426f-b963-21952d9aa42e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+e3cebc0f-6eb6-4556-9d99-dc1671ac3d1b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+e3dac103-f033-4d5c-b59a-a76f7ac96b0d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e411110b-a209-465f-8bd4-d2575fdfecee,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+e41c8757-1e6e-4127-8ece-57ed5377f571,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+e4370a7c-b557-4905-961d-30f60ba4cb53,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e442da1a-0747-4820-a035-9c42e81674d8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e47585cf-d657-443f-8264-a23a632c7ea9,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+e4b77563-2381-4675-ad73-872635adb706,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e4f7e439-ed76-4b4c-aae7-1779e0effd18,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+e4fbb09a-6a30-4a35-900e-f38e7dea477c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e5465d91-3d7a-4996-93dd-d75d8b58c47d,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+e5ed26f3-6421-47c2-8ffd-b1d2fb0cb3fe,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+e5f57ba1-6fca-484d-963b-6aea099c9e2e,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+e63064e0-2b73-4dea-8baa-ce624da3d548,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+e677a06b-6ab8-406e-b928-d32dbe9d8b18,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+e67c3a2c-29b8-4432-9a8d-dae98bf73d73,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+e67f228a-24e7-46d6-8009-f56e726f83ef,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e68e1e30-642d-4dcf-93cd-a892388cf2f0,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+e690462f-b047-4ff4-90c8-561d8561fa05,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+e6a76441-9715-45f4-9347-b06e7681deac,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e6b2ef50-6b09-4f16-bf2a-1612c02d0513,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e6e64e85-11d5-4d8b-b63d-a57741a6c56d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e7aba6cb-1cfc-446e-ba02-57ec079f58ca,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+e823b2e6-f39f-4874-ae87-08e7974289af,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e8555b3d-5f66-47b3-bd2b-26f813e29e9c,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+e86eea07-ed74-49ed-8b1e-4756d96c97b0,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e88a5477-4ac7-456a-bcc2-b244075477e8,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+e8971650-8dd4-4715-9261-0d88530e5378,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+e8bbf85a-26ac-4e76-b4eb-0100d552ea08,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+e8e43492-b016-4876-ae2a-882591666ee1,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+e8ebf9f2-f5af-4876-ad04-8a1ab58c9bc6,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+e8f13fa2-d740-4d81-8b04-357b34c1a8da,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+e8f1a6fc-8b0b-4ff2-9717-c9eb972cb5e7,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+e9232d00-b55a-483a-a4a0-d1db4e28297b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+e944c6f8-c5e9-43ac-9c6d-9f97131c25c5,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+e9cc08e8-1e96-4679-aa93-bfac21ab5341,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+e9db6606-bf97-4158-baf7-21c1ff88fd02,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+e9dca07c-eaf8-45a9-a399-13c09cbc6577,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+ea1e3d90-6efa-4437-a735-f30cd81456e2,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ea26f0f9-094f-4aec-bd2e-104f039f951c,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+ea6b6af2-3aa8-45fe-823d-f9255a591a11,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+eab05816-2004-4c79-8cc3-ea94f245a66e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+eac83d39-8155-40a7-94b2-093d4d87cc94,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+eb0771b9-5433-4590-932c-deaa3eced2f8,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+eb08beaa-4fe5-44ce-bcd6-bfa5c993e4a1,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+eb86cdd6-a684-4ccb-8d39-ff6cad9bace3,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+eba39a86-40a7-4b8b-9319-2992af885bfa,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ec206fa2-012d-43da-ae90-21ce43366681,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+ec322fc5-b50a-4aa5-b01c-89aa1fdd0e7f,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ec5946e0-d90c-4f68-98cd-5d278935ccde,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ec6622c6-d28a-4c92-aa2b-dd86a3da274a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ec86edc8-0c96-4e72-b542-71cacd9a23d4,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+ecd868c0-65cb-492b-a6af-c4e948c31695,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ecdc0d70-63e7-4655-ab2c-93fb1f7b90fe,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+ecf60dd2-7de3-43d7-b363-ec847d51baed,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+ed1ef0fd-1729-44b3-8640-4fff288d85f1,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ed3729b3-580e-407d-b874-6466008d9d24,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ed4d7bc3-d05a-41df-87f7-c31721f80378,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ed60af4d-889d-4a5a-9498-9d32bbe99642,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ed6ddc8e-3704-472a-8ef9-29f940963aec,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ed7818a9-3749-4969-8f30-878ede4315a0,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+eda08c7a-cbfc-48c5-9c5a-e34b6980fe0b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+edec8d32-ce3d-443e-9480-2b7b808ba290,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+edee3f8a-0dc7-4527-9e75-780742b333b3,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ee3795d2-ff2b-476d-86e7-d5175e209876,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ee6c911a-a149-4945-bd02-79eb1de0d670,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+eed33d20-9500-457c-8f1d-02d78b0978c2,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+eee69781-8a40-4be3-87f2-fc3775d12209,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+eefe8a6f-8079-4e6d-85d3-5defdf6add2e,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ef0dfa3b-140b-493c-aabb-1de18aaa901e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+efa4c521-3f3e-43d0-866b-9168d888163e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+efb6d14b-d026-4f30-9ba4-eff2484b5408,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+efe64b3d-92eb-4b30-a7b1-5db45f71ed3c,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+efee3765-6e51-468a-a846-26dd2e703637,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+eff50742-7c6d-4cc7-80ef-856167fd3ae9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f00db189-8635-4b57-9c34-f97e3f648a50,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f0330afa-92ea-4338-88a6-6a4de0877197,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f064d2f9-3215-49ca-b3d7-4babc336db5d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f07df1b3-0d2b-45c8-8cdd-2bbf4c584311,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f08e2f03-849d-46a8-8113-52945d5aa6f9,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f0dcb844-1524-446f-905b-3b1de55a0ff7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f0e1fe95-e712-4996-8ad2-e0fd1732c207,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f0f12a48-52ee-40e0-b419-f1ecbe86909c,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f10bec41-2a65-40a4-845d-643be644f1c5,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+f118465c-46b1-4071-bea1-cf5dfd308c02,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+f11ae7a3-8369-4b92-ba84-ea79e18b100e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f11dccf2-6a81-44ef-a886-ffdfb4d4c055,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f136679d-24b7-4733-8057-c55d51a9e384,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f14904f2-9084-4ae5-a1ab-5de4d8a122a7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f183a7a2-2e7b-467f-973a-1e2a8f2d00e2,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f189f46a-3eee-4c24-a063-9686a91aa907,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f1b1fdb6-56dc-4d75-bfc2-92829a29dc4d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f1cff3fc-6069-40b6-926c-dbf464bf3871,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f2123be2-da07-4fef-b693-c9f889f0a129,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f2434bfd-f21f-433b-9eca-af243afa06bc,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f2479be0-0e7c-49c3-aa91-76f8b78f8c00,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+f255c30d-ef1b-4d42-afd7-8ef049b5c2c0,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+f263b942-41cc-4942-9728-5ec5d4f17c64,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f2858e14-102d-4978-94ba-6516405c9ea8,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+f2c3d9f1-b48b-45d9-9bf8-769002e0525c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f2d0f81e-7e1d-4e88-aadb-a5895b9fedbf,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f3284db7-0498-4a3a-a41f-f7f08f79a8dc,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f35141c6-54fc-44f5-b5cf-cb67040462ce,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f355c036-604b-44a1-8eca-074e23825909,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f369715f-2e58-44b1-9d96-75af2d04195f,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+f372f788-f008-4f60-83a9-88bc69ebe9a2,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f3751044-768f-487f-92c1-f48766244a9e,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f375b48d-6bd4-4436-aef2-272287659aea,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f385e4cf-0981-4b58-b5d5-4b7eb5fe1d6c,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+f3a38a6a-bf86-443e-a783-65f028d5471f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f3ce0936-2567-4f4a-bd47-c48cb8f7e85f,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f3e83225-ed6e-4fc6-8496-f51c2658f14d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f3e8cd9d-b810-4a29-acf0-024922d4d399,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f3fac763-f1d4-4387-af99-1f470aaecab1,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f4032bd1-31cf-4749-8af5-435ed0e7fde9,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f44d491c-192d-451e-8df4-21e3a4ebfa66,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f4a17635-9477-4448-9aed-060033af317a,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+f4ae9848-fa11-4aad-897f-ea69c3eaef72,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+f4b5736f-fe04-4f21-8ffa-0c863f938b4a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f4c3adfc-2e16-4867-be78-2392d022add5,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f4e9f450-4d2d-4363-aaa7-d038f6ea8f2b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f4f48ca7-b413-4303-92b3-29061aa9d2b8,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+f51ac1c5-8476-47ef-bb52-e488128d5f1e,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f561d550-fb52-4603-935c-9c0a86253bd4,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f59833e2-b3b6-41b8-86f3-009eeb29189c,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f59b296c-d4e2-4ba5-9408-eecba966b35a,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f59f1d50-8168-4028-92cd-b75f61251e70,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f5ae7091-b5b5-4b9f-8056-68e81fba0440,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f5ba3c0f-97d9-452b-9d4a-6a59a28f9ab7,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f5c347bc-e360-40f4-b9ae-a0a86f72cc87,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+f5c8dcc5-05f4-4018-b52e-7ba6d1734150,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+f5cb4d59-7d9a-4cc8-92db-b59e9e13ae12,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f5d3a455-f5ba-4b50-aef2-1920836ceacf,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+f5fc0d17-b0a8-4ed9-ba2e-c14ed7916372,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f5fc7109-8771-4a6e-a103-981a8c2e90c8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f62cbeb5-79dd-44b7-94fb-9ae65e224f8e,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+f643d217-1bba-40f3-8818-65bd89f34c8c,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+f667b966-1b07-4a5d-9632-210cab6332a1,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f6a7d9a5-3eac-4247-8818-f21d65872ffe,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f6bb73ab-79b8-4ef0-8691-5453773fdcf6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f6f91869-69ef-4be9-b211-1a5296fa8453,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f70c3d71-6a0a-4ead-b058-05bde0bbe573,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+f72f3470-f542-423b-abbb-5a25391664de,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f730f727-1c3d-4fd1-af0d-d31e9e52f18b,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+f743309f-02fd-4a2a-9ea5-939649cf91ef,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f75e11c0-85af-476a-9f44-978d36ee52c0,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f77a97cb-2720-4cc4-9162-742a718f540a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f78365b4-1fe8-4756-adfc-335e502d5fc6,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+f7ad728f-9f64-4a50-a8ad-d485df88e8b8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f7c5cb86-ad45-43d8-8af1-67d239f78688,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+f803791b-5bc4-4a1e-bcc0-35a9431bf91a,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f81b63e2-346b-4ebb-adb7-28ca9233ea32,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+f87435c7-db90-4522-9c22-77854c769cb2,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f8a02aae-d6d9-4275-b3ee-7c0d238a62e2,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+f8fe93a5-5d0d-44ae-960a-1f1add279f5a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+f96d803c-2204-456f-a000-0829cad2217b,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+f970b8e4-3ae3-4068-a342-904a903f5665,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+f97b0fac-d18e-49ca-9179-c7fa1414a8ef,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+f984c244-284e-47f0-9df1-62e792e0f8da,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+f98cc0b6-97ed-4cbe-993c-dc338d1d4d2a,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+f9a3fe88-fae9-4742-99ae-5476465621f2,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+fa517bac-805e-40df-adf7-9b78d80b3496,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+fa7de663-e47c-471e-806f-c44afdd05dc8,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+faa5c638-7897-4a52-bce1-a7028f0e98be,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+faa883fe-e7e8-49ab-b0a1-ddc89f93a67f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+fad3de55-cecd-4f3e-8983-b73ba42c45fd,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+faef679c-341e-4f6f-9af1-e1565c649552,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+fb355b7a-fcbf-4708-8f63-6ec72a198173,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+fb5b33d7-7350-4e52-bcd0-8516d68b8657,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+fb5b3964-ecec-414e-8b4f-32a4e7ed4e36,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+fb668ae2-a70b-4893-ac18-406a2f236c4a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+fb86858b-c085-4c9b-b026-f02f63ae1bf4,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+fb9dfe6b-d17c-4bb0-89ca-21ff94c54fbf,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+fbafc82b-9c99-4b9e-8356-e8ae5e85bc33,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+fbb689ce-149e-4a43-b78e-d20502d8a5af,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+fbc3a51f-3139-47af-9804-01dd8451d36c,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+fbc3f4d6-1234-4930-af04-3d108c31b39f,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+fbce2922-cb22-4610-a615-70344ab39bce,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+fbd65245-7507-4a22-9994-2b0555fb81c1,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+fc0ae25b-f93b-4b24-88c3-e4d52fe3ced6,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+fc1838cf-ee60-4c87-a4cc-11e834e2c7a1,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+fc202883-6fe9-4922-8fda-969ead013fdd,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+fc5ba24f-c271-4049-b862-a9c3d4e1797c,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+fc6b095e-1204-4beb-acc2-57b4a4fbc1a5,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+fc72f289-ca61-4e8f-8f0e-9852548ea79c,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+fc776f05-3132-41e3-bda5-01d798ab3132,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+fc7ad481-5abd-46c7-a290-e41572665048,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+fca89a95-d4af-418c-a764-0ca23eea67a1,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+fcc917c3-9198-4fbf-88fc-2dc13ee62fc2,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+fd10f849-254c-4960-bb0e-ca4f7e30fffa,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+fd11fb63-e69c-4565-8f8e-49906e104274,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+fd2a79c1-e805-46a4-b452-724486e2239c,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+fd3a8c06-7b49-4728-9a75-6b33d568fd03,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+fd51d034-5244-46a7-afc6-03031dd54c75,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+fd64a16c-2840-453a-b7e3-2f17af31a389,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+fd8932d3-48b6-49b3-bce8-23b7a462e9a3,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+fda24fac-bb52-4fbd-b82b-495e51f05693,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+fdabc9fd-bfaa-40b4-b2df-ff51e84e50bb,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+fdce6b38-a409-43c7-bdc0-2b1dc48d0ea7,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+fdd33175-38b9-4670-b288-ee70c63eca3a,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+fdf1a6e9-318a-45e6-8d9b-9af3e35a020d,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+fe2dd16d-2214-49c7-9088-2fe1ae5669af,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+fe350f40-7b10-4674-bfd5-2b35da6ea743,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+fe71db4b-4c80-46fa-8fa6-412b4034c430,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+fe72a627-4682-4f29-b1d5-8cf2ded5be4d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+feebba03-b20d-437c-8e28-046d52bd0b60,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+fef5b5bf-641e-41e2-b5ed-b832ee35c849,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+ff1e9471-702c-4adf-95e8-8a3e068149ee,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+ff2f0284-26e2-4578-ba11-e1e45a5d768a,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ff3174fb-397c-4b10-98e5-ed12ef5be521,29229,1c002488-11a4-4bfa-a94d-b14661fe8aea,Funktionen in Körperschaften und Anstalten des öffentlichen Rechts
+ff43a194-a6a1-48a7-a67d-f3d027e0b60f,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ff62d27d-2152-4919-bbf8-5ff96fd28bb4,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+ff85868e-9d0f-4bde-b57a-b6ae0f35a776,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ff883863-b511-457a-b3f7-6499db9375c2,29228,b27051ac-69a8-418a-a83c-0efe2a3a0476,Funktionen in Unternehmen
+ff88af97-fd97-4369-a6f3-17a49eb8dad8,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ff944fd1-ab40-45f7-a95b-0cd9ddf0047d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+ffc5b1bd-4567-48b2-b48f-f79626b36198,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ffc78100-aa6c-48e9-96db-332c391af63d,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+ffd416af-2bf5-4f4f-960b-92f0b5b42bb2,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ffd88c8a-6b5a-41a2-8ea1-1b4cb9f33075,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"
+ffe1a194-3fca-4506-badf-7a39fb3aa6a6,29647,3b4e469d-51d8-459d-836a-e8f1d45424fc,Entgeltliche Tätigkeiten neben dem Mandat
+ffec8ee6-9462-472c-87e4-6e92ffb3d734,29230,66e5076f-4f6f-4c69-abf1-f9b5e290836c,"Funktionen in Vereinen, Verbänden und Stiftungen"


### PR DESCRIPTION
Ist nicht so elegant, die CSV ins Repo zu packen, war für mich jetzt aber der schnellste weg, ohne mit den verschiedenen Projektversionen und Ordnerstrukturen ins Hadern zu kommen. AW-6025 ist Folgeticket, um die CSV wieder zu entfernen