### PR TITLE
Hotfix: Fehlermeldung in der API Ausgabe der Abgeordneten

### DIFF
--- a/httpdocs/sites/all/modules/custom/pw_api/pw_api.profiles.inc
+++ b/httpdocs/sites/all/modules/custom/pw_api/pw_api.profiles.inc
@@ -256,7 +256,8 @@ function pw_api_user_to_array($user, $subsets = array()) {
 
     // add constituency
     $profile['constituency'] = array();
-    if($w_user->field_user_constituency->value != NULL){
+    $constituency = $w_user->field_user_constituency->value();
+    if(is_array($constituency) && isset($constituency[0]) && is_object($constituency[0])){
       $profile['constituency']['name'] = $w_user->field_user_constituency[0]->label();
       $profile['constituency']['uuid'] = $w_user->field_user_constituency[0]->uuid->value();
       $profile['constituency']['number'] = $w_user->field_user_constituency[0]->field_constituency_nr->value();

--- a/httpdocs/sites/all/modules/custom/pw_api/pw_api.profiles.inc
+++ b/httpdocs/sites/all/modules/custom/pw_api/pw_api.profiles.inc
@@ -256,7 +256,7 @@ function pw_api_user_to_array($user, $subsets = array()) {
 
     // add constituency
     $profile['constituency'] = array();
-    if(sizeof($w_user->field_user_constituency) > 0){
+    if($w_user->field_user_constituency->value != NULL){
       $profile['constituency']['name'] = $w_user->field_user_constituency[0]->label();
       $profile['constituency']['uuid'] = $w_user->field_user_constituency[0]->uuid->value();
       $profile['constituency']['number'] = $w_user->field_user_constituency[0]->field_constituency_nr->value();


### PR DESCRIPTION
Problem: $user->field_user_constituency ist nicht unbedingt leer, es kann ein Array mit der Struktur $user->field_user_constituency[0][tid]=null oder so ähnlich sein. sizeof zählt nur die Elemente im Array. $w_user->field_user_constituency->value() dagegen gibt ein Array der Struktur $array[0]=>OBJECT_OF_CONSTITUENCY zurück. 

$w_user->field_user_constituency[0]->uuid->value() hat dann die Exception gefeuert