### PR TITLE
Awt 185 admin menu input

### DIFF
--- a/src/scss/_drupal.scss
+++ b/src/scss/_drupal.scss
@@ -7,10 +7,14 @@
 /* Admin-Menu */
 #admin-menu {
   z-index: 99999;
-}
-#admin-menu .dropdown {
-  &:after {
-    content: none;
+  .dropdown {
+    &:after {
+      content: none;
+    }
+  }
+  .admin-menu-search input {
+    height: auto;
+    line-height: 14px;
   }
 }
 

--- a/src/scss/_forms.scss
+++ b/src/scss/_forms.scss
@@ -2,6 +2,8 @@
 * Forms
 */
 
+
+
 .form__item {
   margin-bottom: $space-xsmall;
   position: relative;
@@ -39,11 +41,12 @@
       width: 100%;
     }
 
-    @include placeholder {
+    @include placeholder-text {
       font-weight: 300;
       color: $darkGray;
+      opacity: 1;
     }
-
+    
     &:focus {
       border-color: $orange;
     }

--- a/src/scss/mixins/_placeholder.scss
+++ b/src/scss/mixins/_placeholder.scss
@@ -1,4 +1,4 @@
-@mixin placeholder {
+@mixin placeholder-text {
   &::-webkit-input-placeholder {
     @content;
   }


### PR DESCRIPTION
Neben dem Fix für die Admin-Leiste, habe ich noch eine kleine Korrektur für die input-Placeholder hinzugefügt: Das mixin mit dem Name "placeholder" wird bereits von bourbon bereitgestellt, sodass es erneut zu einer Warnmeldung (Deprecation) kam. Ich habe daher nun das neu hinzugefügt mixin umbenannt.