### PR TITLE
AWT-20 restrict newsletter overlay

### DIFF
--- a/httpdocs/sites/all/modules/custom/pw_globals/pw_globals.module
+++ b/httpdocs/sites/all/modules/custom/pw_globals/pw_globals.module
@@ -688,6 +688,21 @@ function _pw_globals_politician_search_role_condition($parliament_term) {
 }
 
 /**
+ * Returns TRUE if the context is a newsletter-specific page
+ */
+function _pw_globals_is_newsletter_page() {
+  if (
+    current_path() === 'node/10380' ||
+    current_path() === 'node/10508' ||
+    current_path() === 'node/111893'
+  ) {
+    return TRUE;
+  } else {
+    return FALSE;
+  }
+}
+
+/**
  * Checks if given profile is open for questions.
  *
  * @param object $account

--- a/httpdocs/sites/all/modules/custom/pw_globals/pw_globals.module
+++ b/httpdocs/sites/all/modules/custom/pw_globals/pw_globals.module
@@ -691,10 +691,11 @@ function _pw_globals_politician_search_role_condition($parliament_term) {
  * Returns TRUE if the context is a newsletter-specific page
  */
 function _pw_globals_is_newsletter_page() {
+  $current_path = current_path();
   if (
-    current_path() === 'node/10380' ||
-    current_path() === 'node/10508' ||
-    current_path() === 'node/111893'
+    $current_path === 'node/10380' ||
+    $current_path === 'node/10508' ||
+    $current_path === 'node/111893'
   ) {
     return TRUE;
   } else {

--- a/httpdocs/sites/all/themes/custom/parliamentwatch/js/script.js
+++ b/httpdocs/sites/all/themes/custom/parliamentwatch/js/script.js
@@ -751,21 +751,6 @@
   };
 
   /**
-   * Attaches the newsletter cookie.
-   *
-   * @type {Drupal~behavior}
-   *
-   * @prop {Drupal~attachBehavior}
-   */
-  Drupal.behaviors.newsletterCookies = {
-    attach: function (context) {
-      if ($('#node-111893').length === 1 || $('#node-10380').length === 1) {
-        $.cookie('modal_newsletter', '1', {path: '/'});
-      }
-    }
-  };
-
-  /**
    * Attaches the tabs behavior.
    *
    * @type {Drupal~behavior}
@@ -2312,6 +2297,11 @@
               $('body').addClass('block-scrolling');
             }
           });
+        }
+
+        // Hide Newsletter-Overlay on sign-up/out pages
+        if ($('#node-111893').length === 1 || $('#node-10380').length === 1) {
+          $.cookie('modal_newsletter', '1', {path: '/'});
         }
       });
     }

--- a/httpdocs/sites/all/themes/custom/parliamentwatch/js/script.js
+++ b/httpdocs/sites/all/themes/custom/parliamentwatch/js/script.js
@@ -751,6 +751,21 @@
   };
 
   /**
+   * Attaches the newsletter cookie.
+   *
+   * @type {Drupal~behavior}
+   *
+   * @prop {Drupal~attachBehavior}
+   */
+  Drupal.behaviors.newsletterCookies = {
+    attach: function (context) {
+      if ($('#node-111893').length === 1 || $('#node-10380').length === 1) {
+        $.cookie('modal_newsletter', '1', {path: '/'});
+      }
+    }
+  };
+
+  /**
    * Attaches the tabs behavior.
    *
    * @type {Drupal~behavior}

--- a/httpdocs/sites/all/themes/custom/parliamentwatch/templates/page.tpl.php
+++ b/httpdocs/sites/all/themes/custom/parliamentwatch/templates/page.tpl.php
@@ -180,7 +180,7 @@ M445.2,31H445l0.1-0.1V31z"/>
     <?php endif; ?>
   </footer>
 
-  <?php if ($GLOBALS['theme_key'] === 'parliamentwatch'): ?>
+  <?php if ($GLOBALS['theme_key'] === 'parliamentwatch' && _pw_globals_is_newsletter_page() === FALSE): ?>
     <div class="modal modal--newsletter" data-modal-initial data-modal-cookie data-modal-cookie-expires="7" data-modal-clicksToShow="3" data-modal-name="modal_newsletter">
       <div class="modal__container">
         <div class="modal__content">


### PR DESCRIPTION
Ich habe zum einen eine Funktion hinzugefügt, um dort die Seiten zu definieren, die keinen Newsletter-Overlay mehr zeigen sollen bzw. die Seiten die mit der Newsletter-Anmeldung zu tun haben.
Diese Funktion nutze ich dann, um das Overlay auf den Seiten nicht mehr auszugeben.

Via JS setze ich den Cookie, als Session-Cookie auf den gewünschten Unterseiten.