### PR TITLE
AWT-50 topic tracking

### DIFF
--- a/httpdocs/sites/all/themes/custom/parliamentwatch/js/script.js
+++ b/httpdocs/sites/all/themes/custom/parliamentwatch/js/script.js
@@ -2272,19 +2272,21 @@
   Drupal.behaviors.deputyGallery = {
     attach: function () {
       $(function() {
-        var deputy_name = $('.deputy__title').text();
+        if(typeof _paq !== "undefined") {
+          var deputy_name = $('.deputy__title').text();
 
-        $('.deputy__gallery a[data-lightbox]').click(function() {
-          _paq.push(['trackEvent', 'User-Gallery', 'Open Image', deputy_name]);
-        });
+          $('.deputy__gallery a[data-lightbox]').click(function () {
+            _paq.push(['trackEvent', 'User-Gallery', 'Open Image', deputy_name]);
+          });
 
-        $('.page-user .lb-next').click(function() {
-          _paq.push(['trackEvent', 'User-Gallery', 'Open next Image', deputy_name]);
-        });
+          $('.page-user .lb-next').click(function () {
+            _paq.push(['trackEvent', 'User-Gallery', 'Open next Image', deputy_name]);
+          });
 
-        $('.page-user .lb-prev').click(function() {
-          _paq.push(['trackEvent', 'User-Gallery', 'Open previous Image', deputy_name]);
-        });
+          $('.page-user .lb-prev').click(function () {
+            _paq.push(['trackEvent', 'User-Gallery', 'Open previous Image', deputy_name]);
+          });
+        }
       });
     }
   };

--- a/httpdocs/sites/all/themes/custom/parliamentwatch/js/script.js
+++ b/httpdocs/sites/all/themes/custom/parliamentwatch/js/script.js
@@ -2242,6 +2242,25 @@
   };
 
   /**
+   * Attaches topic-tag tracking behavior.
+   *
+   * @type {Drupal~behavior}
+   *
+   * @prop {Drupal~attachBehavior}
+   */
+  Drupal.behaviors.topicTagTracking = {
+    attach: function () {
+      $(function() {
+        var page_url = window.location.href;
+
+        $('#topic-tags a').click(function() {
+          _paq.push(['trackEvent', 'Topic Tag', 'Click', page_url]);
+        });
+      });
+    }
+  };
+
+  /**
    * Attaches user gallery tracking behavior.
    *
    * @type {Drupal~behavior}

--- a/httpdocs/sites/all/themes/custom/parliamentwatch/js/script.js
+++ b/httpdocs/sites/all/themes/custom/parliamentwatch/js/script.js
@@ -2251,11 +2251,13 @@
   Drupal.behaviors.topicTagTracking = {
     attach: function () {
       $(function() {
-        var page_url = window.location.href;
+        if(typeof _paq !== "undefined") {
+          var page_url = window.location.href;
 
-        $('#topic-tags a').click(function() {
-          _paq.push(['trackEvent', 'Topic Tag', 'Click', page_url]);
-        });
+          $('#topic-tags a').click(function() {
+            _paq.push(['trackEvent', 'Topic Tag', 'Click', page_url]);
+          });
+        }
       });
     }
   };

--- a/httpdocs/sites/all/themes/custom/parliamentwatch/templates/field--field-topics.tpl.php
+++ b/httpdocs/sites/all/themes/custom/parliamentwatch/templates/field--field-topics.tpl.php
@@ -51,7 +51,7 @@
       <?php print render($item); if ($delta < (sizeof($items) - 1)) print ', '; ?>
     <?php endforeach; ?>
   <?php else: ?>
-    <ul class="tag-list">
+    <ul id="topic-tags" class="tag-list">
       <?php foreach ($items as $delta => $item): ?>
         <li><?php print render($item); ?></li>
       <?php endforeach; ?>


### PR DESCRIPTION
Habe dem Feld-Template, welcher für das Rendering an verschiedenen Stellen zuständig ist, eine eigene CSS-ID hinzugefügt, um diese im Javascript anzusprechen.

Mir ist aufgefallen, dass es nun einen Tag-Manager für Matomo gibt, den man wohl aber erst mal noch freischalten muss. Es scheint dem Google Tag-Manager in der Funktion sehr zu ähneln, was die Organisation und das bearbeiten des Trackings und dessen Selektoren deutlich verbessern würde.

Meiner Meinung sollten wir vorerst von weiteren Tracking-Implementierungen absehen und den Tag-Manager prüfen und ggfs. einrichten.  