### PR TITLE
AWT-235 Enlarge the size of nav-trigger

### DIFF
--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -498,9 +498,7 @@ body {
   color: $gray;
   position: relative;
   z-index: 9999999;
-  padding: 5px;
-  right: $space-small;
-  @include margin(($space - 5px) null);
+  padding: $space;
   @include breakpoint($breakpoint-m-min) {
     display: none;
   }


### PR DESCRIPTION
Konnte das Problem bei mir im iOS-Simulator, als auch auf dem nativen Endgerät (iPhone 6) reproduzieren und durch das vergrößern der Klickfläche deutlich verbessern.

Auf dem im Ticket angegebenen Android-System konnte ich es final nicht testen.