### PR TITLE
AWT-187 scroll offset

### DIFF
--- a/httpdocs/sites/all/themes/custom/parliamentwatch/js/script.js
+++ b/httpdocs/sites/all/themes/custom/parliamentwatch/js/script.js
@@ -609,34 +609,6 @@
   };
 
   /**
-   * Attaches local scroll behavior on page load.
-   *
-   * @type {Drupal~behavior}
-   *
-   * @prop {Drupal~attachBehavior}
-   */
-  Drupal.behaviors.initLocalScrollPageLoad = {
-    attach: function (context) {
-      function scrollToAnchor(hash) {
-        var target = $(hash);
-
-        target = target.length ? target : $('[name=' + hash.slice(1) +']');
-
-        if (target.length) {
-          $('html,body').animate({
-            scrollTop: target.offset().top
-          }, 100);
-          return false;
-        }
-      }
-
-      if(window.location.hash) {
-        scrollToAnchor(window.location.hash);
-      }
-    }
-  };
-
-  /**
    * Attaches the tooltip behavior.
    *
    * @type {Drupal~behavior}

--- a/src/scss/_utilities.scss
+++ b/src/scss/_utilities.scss
@@ -43,17 +43,6 @@ textarea {
   border: 0;
 }
 
-/* Local Anchor */
-
-.local-anchor {
-  @include breakpoint($breakpoint-l-min) {
-    position: relative;
-    top: -123px;
-    display: block;
-    visibility: hidden;
-  }
-}
-
 /* Links with icons */
 
 .link-icon {


### PR DESCRIPTION
Es gab zwei Altlasten die dieses Fehlverhalten erzeugt hatten, die seit der finalen Umstellung des Header-Verhaltens (Sticky/Scrollable) nicht mehr notwendig sind.