### PR TITLE
AWT-110 Add intro-container to webform headline

### DIFF
--- a/httpdocs/sites/all/themes/custom/parliamentwatch/templates/node--65995--full.tpl.php
+++ b/httpdocs/sites/all/themes/custom/parliamentwatch/templates/node--65995--full.tpl.php
@@ -7,9 +7,11 @@
 ?>
 <div class="container-small">
   <div id="node-<?php print $node->nid; ?>" class="webform-container clearfix <?php print $classes; ?>"<?php print $attributes; ?>>
-    <?php print render($title_prefix); ?>
-    <h1><?php print $title; ?></h1>
-    <?php print render($title_suffix); ?>
+    <div class="intro">
+      <?php print render($title_prefix); ?>
+      <h1><?php print $title; ?></h1>
+      <?php print render($title_suffix); ?>
+    </div>
 
     <?php if ($display_submitted): ?>
       <div class="submitted">

--- a/src/scss/_webform.scss
+++ b/src/scss/_webform.scss
@@ -50,6 +50,9 @@
 }
 .webform-container {
   @include basic-content();
+  .intro h1 {
+    margin: 0;
+  }
 }
 
 .webform-component-fieldset {


### PR DESCRIPTION
Als angemeldeter Nutzer hat man leider einen fehlenden Abstand der Headline nicht bemerkt.
Ich habe nun hier den entsprechende intro-container hinzugefügt, sodass hier der einheitliche Abstand zwischen Headline, Header und dem Inhalt gewährleistet ist.