### PR TITLE
AWT-445 prevent multipost

### DIFF
--- a/httpdocs/sites/all/themes/custom/aw_admintheme/aw_admintheme.info
+++ b/httpdocs/sites/all/themes/custom/aw_admintheme/aw_admintheme.info
@@ -4,3 +4,4 @@ core = '7.x'
 base theme = 'seven'
 
 stylesheets[all][] = css/aw_admintheme.css
+scripts[] = 'js/scripts.js'

--- a/httpdocs/sites/all/themes/custom/aw_admintheme/css/aw_admintheme.css
+++ b/httpdocs/sites/all/themes/custom/aw_admintheme/css/aw_admintheme.css
@@ -53,3 +53,11 @@
 .paragraph-item--person__info {
     flex: 1 1 calc(100% - 80px);
 }
+
+
+/* User-profile form */
+
+.form-submit--loading {
+    opacity: .4;
+    pointer-events: none;
+}

--- a/httpdocs/sites/all/themes/custom/aw_admintheme/js/scripts.js
+++ b/httpdocs/sites/all/themes/custom/aw_admintheme/js/scripts.js
@@ -1,0 +1,22 @@
+/**
+ * Add function for preventing multiple form submissions
+ */
+
+jQuery.fn.preventMultiPost = function() {
+    jQuery(this).on('submit',function(e){
+        var $form = jQuery(this);
+
+        if ($form.data('submitted') === true) {
+            e.preventDefault();
+        } else {
+            $form.find('#edit-submit').addClass('form-submit--loading');
+            $form.data('submitted', true);
+        }
+    });
+    return this;
+};
+
+jQuery(document).ready(function() {
+    // Trigger preventMultiPost() for user edit-formular
+    jQuery('#user-profile-form').preventMultiPost();
+});


### PR DESCRIPTION
Habe zunächst versucht, die gleiche Mechanik aus unserem Frontend-Theme zu übernehmen, jedoch gab es probleme mit dem disabled-attribut, welches hier gesetzt wird. Sobald das disabled-attribut auf der form-submit Schaltfläche gesetzt wird, kann das Formular nicht mehr korrekt abgesendet werden. Es wird lediglich die Seite neu geladen, ohne die Anpassungen in die Datenbank zu schreiben.

Ich habe daher nun eine andere Methode implementiert und eine CSS-Klasse gesetzt, um die Schaltfläche auszugrauen und die Schaltfläche nicht mehr klickbar zu machen.